### PR TITLE
feat: HierarchicalIntentDeterminationEngine 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ Adapt Intent Parser
 ==================
 The Adapt Intent Parser is a flexible and extensible intent definition and determination framework. It is intended to parse natural language text into a structured intent that can then be invoked programatically.
 
-This repository contains a OVOS pipeline plugin and bundles a fork of the original [adapt-parser](https://github.com/MycroftAI/adapt) from the defunct MycroftAI
+This repository contains a OVOS pipeline plugin and bundles a fork of the original [adapt-parser](https://github.com/MycroftAI/adapt) from the defunct MycroftAI.
+
+Pipeline Plugins
+----------------
+Two OPM pipeline entry points are exposed:
+
+- `ovos-adapt-pipeline-plugin` (`AdaptPipeline`) — the flat pipeline, wrapping a single `IntentDeterminationEngine`. All skills share one trie.
+- `ovos-adapt-domain-pipeline-plugin` (`DomainAdaptPipeline`) — a per-skill pipeline wrapping `DomainIntentDeterminationEngine`. Each `skill_id` gets its own sub-engine ("domain"); at match time every domain is scored in parallel and a global argmax wins. Configurable under `intents.ovos_adapt_domain_pipeline` (`conf_high`, `conf_med`, `conf_low`).
 
 Documentation
 =============

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ This repository contains a OVOS pipeline plugin and bundles a fork of the origin
 
 Pipeline Plugins
 ----------------
-Two OPM pipeline entry points are exposed:
+Three OPM pipeline entry points are exposed:
 
 - `ovos-adapt-pipeline-plugin` (`AdaptPipeline`) — the flat pipeline, wrapping a single `IntentDeterminationEngine`. All skills share one trie.
-- `ovos-adapt-domain-pipeline-plugin` (`DomainAdaptPipeline`) — a per-skill pipeline wrapping `DomainIntentDeterminationEngine`. Each `skill_id` gets its own sub-engine ("domain"); at match time every domain is scored in parallel and a global argmax wins. Configurable under `intents.ovos_adapt_domain_pipeline` (`conf_high`, `conf_med`, `conf_low`).
+- `ovos-adapt-domain-pipeline-plugin` (`DomainAdaptPipeline`) — a per-skill pipeline wrapping `DomainIntentDeterminationEngine`. Each `skill_id` gets its own sub-engine ("domain"); at match time every domain is scored in parallel and a global argmax wins. Configurable under `intents.ovos_adapt_domain_pipeline`.
+- `ovos-adapt-hierarchical-pipeline-plugin` (`HierarchicalAdaptPipeline`) — the per-skill domain model with two-stage routing: a stage-1 classifier picks one domain, then only that domain's sub-engine is scored. Configurable under `intents.ovos_adapt_hierarchical_pipeline`.
+
+See [Pipeline variants](docs/pipelines.md) for when to use each.
 
 Documentation
 =============
@@ -21,8 +24,10 @@ A zero-to-hero guide lives in [`docs/`](docs/index.md):
 - [Quickstart](docs/quickstart.md) — install, enable, match your first utterance
 - [Writing intents](docs/writing-intents.md) — the `IntentBuilder` API with examples
 - [Configuration](docs/configuration.md) — confidence tiers and every config key
+- [Pipeline variants](docs/pipelines.md) — the flat, domain, and hierarchical plugins
 - [Bus protocol](docs/bus-protocol.md) — the messagebus API skills register over
 - [Internals](docs/internals.md) — tagging, clique expansion, the confidence math
+- [Engine comparison reference](docs/benchmark.md) — how the variants diverge
 
 Examples
 ========

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -144,7 +144,7 @@ def run_flat(cases):
 
     m = compute_metrics(results, cases)
     print_report("flat  —  IntentDeterminationEngine", m, latencies)
-    return m, statistics.median(latencies)
+    return m, statistics.median(latencies), results
 
 
 def run_domain(cases):
@@ -166,10 +166,34 @@ def run_domain(cases):
 
     m = compute_metrics(results, cases)
     print_report("domain  —  DomainIntentDeterminationEngine", m, latencies)
-    return m, statistics.median(latencies)
+    return m, statistics.median(latencies), results
 
 
 # ── summary table ──────────────────────────────────────────────────────────
+
+def head_to_head(cases, flat_results, domain_results):
+    """Report the cases where flat and domain predict a different intent."""
+    diffs = []
+    for (utt, expected), (fn, fc), (dn, dc) in zip(cases, flat_results,
+                                                   domain_results):
+        if fn != dn:
+            diffs.append((utt, expected, fn, fc, dn, dc))
+    print(f"\n\n{'=' * 66}")
+    print("  Head-to-head: flat vs domain")
+    print(f"{'=' * 66}")
+    print(f"  Cases             : {len(cases)}")
+    print(f"  Same prediction   : {len(cases) - len(diffs)}")
+    print(f"  Different          : {len(diffs)}")
+    if diffs:
+        print(f"\n  {'utterance':<44} {'expected':<16} {'flat':<16} {'domain':<16}")
+        print(f"  {'-' * 90}")
+        for utt, exp, fn, fc, dn, dc in diffs:
+            u = utt if len(utt) <= 42 else utt[:41] + "…"
+            print(f"  {u:<44} {exp or '—':<16} "
+                  f"{(fn or '—') + f' {fc:.2f}':<16} "
+                  f"{(dn or '—') + f' {dc:.2f}':<16}")
+    return len(diffs)
+
 
 def summary(rows):
     print(f"\n\n{'─' * 84}")
@@ -196,8 +220,9 @@ if __name__ == "__main__":
           f"across {len(VOCAB)} entity types")
 
     rows = []
-    m, lat = run_flat(cases)
+    m, lat, flat_results = run_flat(cases)
     rows.append(("flat", m, lat))
-    m, lat = run_domain(cases)
+    m, lat, domain_results = run_domain(cases)
     rows.append(("domain", m, lat))
+    head_to_head(cases, flat_results, domain_results)
     summary(rows)

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -56,6 +56,10 @@ def _entity_types(intent_names):
     return etypes
 
 
+#: intent_name -> its domain
+INTENT_DOMAIN = {i: d for d, names in DOMAINS.items() for i in names}
+
+
 def _best_name(intents):
     """Global argmax intent label over a list of Adapt parse dicts."""
     if not intents:
@@ -171,6 +175,58 @@ def run_domain(cases):
 
 # ── summary table ──────────────────────────────────────────────────────────
 
+def run_hierarchical(cases):
+    """Two-stage routing: classify the domain, then resolve within it.
+
+    Stage 1 is a domain classifier — a flat engine whose 'intents' are
+    domains, each requiring a pooled keyword entity covering every word
+    used by that domain's intents. Stage 2 runs only the winning domain's
+    sub-engine. A wrong stage-1 route cannot be recovered.
+    """
+    sub = {}
+    for domain, intent_names in DOMAINS.items():
+        engine = IntentDeterminationEngine()
+        for etype in _entity_types(intent_names):
+            for value in VOCAB.get(etype, []):
+                engine.register_entity(value, etype)
+        for intent_name in intent_names:
+            engine.register_intent_parser(_build_parser(intent_name))
+        sub[domain] = engine
+
+    classifier = IntentDeterminationEngine()
+    for domain, intent_names in DOMAINS.items():
+        pooled = set()
+        for etype in _entity_types(intent_names):
+            pooled.update(VOCAB.get(etype, []))
+        for value in pooled:
+            classifier.register_entity(value, f"{domain}_kw")
+        classifier.register_intent_parser(
+            IntentBuilder(domain).require(f"{domain}_kw").build())
+
+    results, latencies = [], []
+    routed_ok = routed_total = 0
+    for utt, expected in cases:
+        t0 = time.perf_counter()
+        domain, _ = _best_name(list(classifier.determine_intent(utt, 100)))
+        if domain in sub:
+            name, conf = _best_name(list(sub[domain].determine_intent(utt, 100)))
+        else:
+            name, conf = None, 0.0
+        latencies.append((time.perf_counter() - t0) * 1000)
+        results.append((name, conf))
+        if expected is not None:
+            routed_total += 1
+            if domain == INTENT_DOMAIN.get(expected):
+                routed_ok += 1
+
+    m = compute_metrics(results, cases)
+    print_report("hierarchical  —  two-stage (classify domain, then intent)",
+                 m, latencies)
+    print(f"  Stage-1 routing : {routed_ok}/{routed_total} match cases "
+          f"routed to the correct domain ({routed_ok / routed_total:.0%})")
+    return m, statistics.median(latencies), results
+
+
 def head_to_head(cases, flat_results, domain_results):
     """Report the cases where flat and domain predict a different intent."""
     diffs = []
@@ -224,5 +280,7 @@ if __name__ == "__main__":
     rows.append(("flat", m, lat))
     m, lat, domain_results = run_domain(cases)
     rows.append(("domain", m, lat))
+    m, lat, _ = run_hierarchical(cases)
+    rows.append(("hierarchical", m, lat))
     head_to_head(cases, flat_results, domain_results)
     summary(rows)

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -1,0 +1,203 @@
+"""
+Comparative accuracy + speed benchmark: flat Adapt vs domain Adapt.
+
+Both runners use the same keyword vocabulary and intent definitions. The
+only difference is engine topology:
+
+- **flat**   — one :class:`IntentDeterminationEngine`; every intent parser
+  and every entity share a single Trie and tagger.
+- **domain** — one :class:`DomainIntentDeterminationEngine`; intents are
+  grouped into domains, each domain owning an isolated sub-engine (its own
+  Trie + tagger). At match time every domain is scored and the global
+  argmax wins.
+
+Usage
+-----
+    python benchmark/compare.py
+"""
+import statistics
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from benchmark.dataset import (  # noqa: E402
+    VOCAB, INTENTS, DOMAINS, TEST_CASES, NO_MATCH_UTTERANCES,
+)
+from ovos_adapt.engine import (  # noqa: E402
+    IntentDeterminationEngine, DomainIntentDeterminationEngine,
+)
+from ovos_adapt.intent import IntentBuilder  # noqa: E402
+
+
+# ── shared helpers ─────────────────────────────────────────────────────────
+
+def all_cases():
+    return list(TEST_CASES) + [(u, None) for u in NO_MATCH_UTTERANCES]
+
+
+def _build_parser(intent_name):
+    slots = INTENTS[intent_name]
+    builder = IntentBuilder(intent_name)
+    for slot in slots["required"]:
+        builder.require(slot)
+    for slot in slots["optional"]:
+        builder.optionally(slot)
+    return builder.build()
+
+
+def _entity_types(intent_names):
+    etypes = set()
+    for name in intent_names:
+        etypes.update(INTENTS[name]["required"])
+        etypes.update(INTENTS[name]["optional"])
+    return etypes
+
+
+def _best_name(intents):
+    """Global argmax intent label over a list of Adapt parse dicts."""
+    if not intents:
+        return None, 0.0
+    best = max(intents, key=lambda x: x.get("confidence", 0.0))
+    conf = best.get("confidence", 0.0)
+    return (best.get("intent_type") if conf > 0 else None), conf
+
+
+def compute_metrics(results, cases):
+    total = len(cases)
+    match_n = sum(1 for _, e in cases if e is not None)
+    nomatch_n = total - match_n
+    tp = fp = fn = tn = 0
+    per_tp = defaultdict(int)
+    per_fn = defaultdict(int)
+    per_fp = defaultdict(int)
+    wrong = []
+    for (predicted, conf), (utt, expected) in zip(results, cases):
+        if expected is not None:
+            if predicted == expected:
+                tp += 1
+                per_tp[expected] += 1
+            else:
+                fn += 1
+                per_fn[expected] += 1
+                if predicted is not None:
+                    fp += 1
+                    per_fp[predicted] += 1
+                wrong.append((utt, expected, predicted, conf))
+        else:
+            if predicted is not None:
+                fp += 1
+                per_fp[predicted] += 1
+                wrong.append((utt, expected, predicted, conf))
+            else:
+                tn += 1
+    prec = tp / (tp + fp) if (tp + fp) else 0.0
+    rec = tp / match_n if match_n else 0.0
+    f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
+    return dict(
+        accuracy=(tp + tn) / total, precision=prec, recall=rec, f1=f1,
+        tp=tp, fp=fp, fn=fn, tn=tn,
+        match_n=match_n, nomatch_n=nomatch_n,
+        per_tp=per_tp, per_fn=per_fn, per_fp=per_fp, wrong=wrong,
+    )
+
+
+def print_report(label, m, latencies):
+    s = sorted(latencies)
+    total = m["match_n"] + m["nomatch_n"]
+    print(f"\n{'=' * 66}")
+    print(f"  {label}")
+    print(f"{'=' * 66}")
+    print(f"  Accuracy  : {m['accuracy']:.1%}  ({int(round(m['accuracy'] * total))}/{total})")
+    print(f"  Precision : {m['precision']:.1%}")
+    print(f"  Recall    : {m['recall']:.1%}")
+    print(f"  F1        : {m['f1']:.3f}")
+    print(f"  TN        : {m['tn']} / {m['nomatch_n']}  ({m['tn'] / m['nomatch_n']:.0%} of no-match)")
+    print(f"  FP        : {m['fp']} / {m['nomatch_n']}  ({m['fp'] / m['nomatch_n']:.0%} of no-match)")
+    print(f"  FN        : {m['fn']} / {m['match_n']}  ({m['fn'] / m['match_n']:.0%} of match)")
+    print(f"  Latency   : median={statistics.median(latencies):.2f}ms  "
+          f"p95={s[int(len(s) * .95)]:.2f}ms  max={s[-1]:.2f}ms")
+    if m["wrong"]:
+        print(f"\n  Mismatches ({len(m['wrong'])}):")
+        for utt, exp, pred, conf in m["wrong"]:
+            print(f"    [{exp or '—'} → {pred or '—'}] ({conf:.2f})  \"{utt}\"")
+
+
+# ── engine runners ─────────────────────────────────────────────────────────
+
+def run_flat(cases):
+    engine = IntentDeterminationEngine()
+    for entity_type, values in VOCAB.items():
+        for value in values:
+            engine.register_entity(value, entity_type)
+    for intent_name in INTENTS:
+        engine.register_intent_parser(_build_parser(intent_name))
+
+    results, latencies = [], []
+    for utt, _ in cases:
+        t0 = time.perf_counter()
+        intents = list(engine.determine_intent(utt, 100))
+        latencies.append((time.perf_counter() - t0) * 1000)
+        results.append(_best_name(intents))
+
+    m = compute_metrics(results, cases)
+    print_report("flat  —  IntentDeterminationEngine", m, latencies)
+    return m, statistics.median(latencies)
+
+
+def run_domain(cases):
+    engine = DomainIntentDeterminationEngine()
+    for domain, intent_names in DOMAINS.items():
+        for etype in _entity_types(intent_names):
+            for value in VOCAB.get(etype, []):
+                engine.register_entity(value, etype, domain=domain)
+        for intent_name in intent_names:
+            engine.register_intent_parser(_build_parser(intent_name),
+                                          domain=domain)
+
+    results, latencies = [], []
+    for utt, _ in cases:
+        t0 = time.perf_counter()
+        intents = list(engine.determine_intent(utt, 100))
+        latencies.append((time.perf_counter() - t0) * 1000)
+        results.append(_best_name(intents))
+
+    m = compute_metrics(results, cases)
+    print_report("domain  —  DomainIntentDeterminationEngine", m, latencies)
+    return m, statistics.median(latencies)
+
+
+# ── summary table ──────────────────────────────────────────────────────────
+
+def summary(rows):
+    print(f"\n\n{'─' * 84}")
+    print(f"  {'Engine':<14} {'Acc':>6} {'Prec':>6} {'Recall':>7} {'F1':>6}  "
+          f"{'TN/NM':>8}  {'FP':>4}  {'FN':>4}  {'Median':>8}")
+    print(f"{'─' * 84}")
+    for label, m, median_lat in rows:
+        tn_frac = f"{m['tn']}/{m['nomatch_n']}"
+        print(f"  {label:<14} {m['accuracy']:>5.1%} {m['precision']:>5.1%} "
+              f"{m['recall']:>6.1%} {m['f1']:>5.3f}  {tn_frac:>8}  "
+              f"{m['fp']:>4}  {m['fn']:>4}  {median_lat:>6.2f}ms")
+    print(f"{'─' * 84}")
+    print(f"  TN/NM = true negatives / total no-match cases (correctly returned nothing)")
+
+
+# ── main ───────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    cases = all_cases()
+    match_n = sum(1 for _, e in cases if e is not None)
+    print(f"\nDataset : {len(cases)} cases  ({match_n} match, {len(cases) - match_n} no-match)")
+    print(f"Intents : {len(INTENTS)}  across {len(DOMAINS)} domains")
+    print(f"Vocab   : {sum(len(v) for v in VOCAB.values())} keyword samples "
+          f"across {len(VOCAB)} entity types")
+
+    rows = []
+    m, lat = run_flat(cases)
+    rows.append(("flat", m, lat))
+    m, lat = run_domain(cases)
+    rows.append(("domain", m, lat))
+    summary(rows)

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -182,7 +182,7 @@ def summary(rows):
               f"{m['recall']:>6.1%} {m['f1']:>5.3f}  {tn_frac:>8}  "
               f"{m['fp']:>4}  {m['fn']:>4}  {median_lat:>6.2f}ms")
     print(f"{'─' * 84}")
-    print(f"  TN/NM = true negatives / total no-match cases (correctly returned nothing)")
+    print("  TN/NM = true negatives / total no-match cases (correctly returned nothing)")
 
 
 # ── main ───────────────────────────────────────────────────────────────────

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -15,6 +15,7 @@ Usage
 -----
     python benchmark/compare.py
 """
+import re
 import statistics
 import sys
 import time
@@ -175,13 +176,43 @@ def run_domain(cases):
 
 # ── summary table ──────────────────────────────────────────────────────────
 
+def _make_domain_classifier():
+    """Stage-1 classifier: route an utterance to its most likely domain.
+
+    Scores each domain by how many utterance characters are covered by that
+    domain's pooled keyword vocabulary (word-boundary matched) and returns
+    the argmax. Returns ``None`` when no domain keyword is present.
+    """
+    pools = {}
+    for domain, intent_names in DOMAINS.items():
+        kws = set()
+        for etype in _entity_types(intent_names):
+            kws.update(VOCAB.get(etype, []))
+        pools[domain] = [re.compile(r"\b" + re.escape(kw) + r"\b")
+                         for kw in kws]
+
+    def classify(utt):
+        u = utt.lower()
+        best_domain, best_score = None, 0
+        for domain, patterns in pools.items():
+            covered = bytearray(len(u))
+            for pat in patterns:
+                for m in pat.finditer(u):
+                    for j in range(m.start(), m.end()):
+                        covered[j] = 1
+            score = sum(covered)
+            if score > best_score:
+                best_score, best_domain = score, domain
+        return best_domain
+
+    return classify
+
+
 def run_hierarchical(cases):
     """Two-stage routing: classify the domain, then resolve within it.
 
-    Stage 1 is a domain classifier — a flat engine whose 'intents' are
-    domains, each requiring a pooled keyword entity covering every word
-    used by that domain's intents. Stage 2 runs only the winning domain's
-    sub-engine. A wrong stage-1 route cannot be recovered.
+    Stage 1 is a keyword-coverage domain classifier. Stage 2 runs only the
+    winning domain's sub-engine. A wrong stage-1 route cannot be recovered.
     """
     sub = {}
     for domain, intent_names in DOMAINS.items():
@@ -193,21 +224,13 @@ def run_hierarchical(cases):
             engine.register_intent_parser(_build_parser(intent_name))
         sub[domain] = engine
 
-    classifier = IntentDeterminationEngine()
-    for domain, intent_names in DOMAINS.items():
-        pooled = set()
-        for etype in _entity_types(intent_names):
-            pooled.update(VOCAB.get(etype, []))
-        for value in pooled:
-            classifier.register_entity(value, f"{domain}_kw")
-        classifier.register_intent_parser(
-            IntentBuilder(domain).require(f"{domain}_kw").build())
+    classify = _make_domain_classifier()
 
     results, latencies = [], []
     routed_ok = routed_total = 0
     for utt, expected in cases:
         t0 = time.perf_counter()
-        domain, _ = _best_name(list(classifier.determine_intent(utt, 100)))
+        domain = classify(utt)
         if domain in sub:
             name, conf = _best_name(list(sub[domain].determine_intent(utt, 100)))
         else:

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -1,21 +1,25 @@
 """
-Comparative accuracy + speed benchmark: flat Adapt vs domain Adapt.
+Engine-comparison harness: flat vs domain vs hierarchical Adapt.
 
-Both runners use the same keyword vocabulary and intent definitions. The
-only difference is engine topology:
+All three runners use the same keyword vocabulary and intent definitions.
+The only difference is engine topology:
 
-- **flat**   — one :class:`IntentDeterminationEngine`; every intent parser
-  and every entity share a single Trie and tagger.
-- **domain** — one :class:`DomainIntentDeterminationEngine`; intents are
-  grouped into domains, each domain owning an isolated sub-engine (its own
-  Trie + tagger). At match time every domain is scored and the global
-  argmax wins.
+- **flat**         — one :class:`IntentDeterminationEngine`; every intent
+  parser and every entity share a single Trie and tagger.
+- **domain**       — one :class:`DomainIntentDeterminationEngine`; intents are
+  grouped into domains, each domain owning an isolated sub-engine. Every
+  domain is scored and the global argmax wins.
+- **hierarchical** — one :class:`HierarchicalIntentDeterminationEngine`; a
+  stage-1 classifier picks one domain, then only that domain's sub-engine is
+  scored.
+
+This is a hand-tuned reference corpus, not a representative benchmark — see
+docs/benchmark.md.
 
 Usage
 -----
     python benchmark/compare.py
 """
-import re
 import statistics
 import sys
 import time
@@ -29,6 +33,7 @@ from benchmark.dataset import (  # noqa: E402
 )
 from ovos_adapt.engine import (  # noqa: E402
     IntentDeterminationEngine, DomainIntentDeterminationEngine,
+    HierarchicalIntentDeterminationEngine,
 )
 from ovos_adapt.intent import IntentBuilder  # noqa: E402
 
@@ -176,74 +181,36 @@ def run_domain(cases):
 
 # ── summary table ──────────────────────────────────────────────────────────
 
-def _make_domain_classifier():
-    """Stage-1 classifier: route an utterance to its most likely domain.
-
-    Scores each domain by how many utterance characters are covered by that
-    domain's pooled keyword vocabulary (word-boundary matched) and returns
-    the argmax. Returns ``None`` when no domain keyword is present.
-    """
-    pools = {}
-    for domain, intent_names in DOMAINS.items():
-        kws = set()
-        for etype in _entity_types(intent_names):
-            kws.update(VOCAB.get(etype, []))
-        pools[domain] = [re.compile(r"\b" + re.escape(kw) + r"\b")
-                         for kw in kws]
-
-    def classify(utt):
-        u = utt.lower()
-        best_domain, best_score = None, 0
-        for domain, patterns in pools.items():
-            covered = bytearray(len(u))
-            for pat in patterns:
-                for m in pat.finditer(u):
-                    for j in range(m.start(), m.end()):
-                        covered[j] = 1
-            score = sum(covered)
-            if score > best_score:
-                best_score, best_domain = score, domain
-        return best_domain
-
-    return classify
-
-
 def run_hierarchical(cases):
-    """Two-stage routing: classify the domain, then resolve within it.
+    """Two-stage routing via HierarchicalIntentDeterminationEngine.
 
-    Stage 1 is a keyword-coverage domain classifier. Stage 2 runs only the
-    winning domain's sub-engine. A wrong stage-1 route cannot be recovered.
+    Registers the same per-domain intents as the parallel domain engine.
+    ``determine_intent`` classifies the domain and resolves only within it;
+    a wrong stage-1 route cannot be recovered.
     """
-    sub = {}
+    engine = HierarchicalIntentDeterminationEngine()
     for domain, intent_names in DOMAINS.items():
-        engine = IntentDeterminationEngine()
         for etype in _entity_types(intent_names):
             for value in VOCAB.get(etype, []):
-                engine.register_entity(value, etype)
+                engine.register_entity(value, etype, domain=domain)
         for intent_name in intent_names:
-            engine.register_intent_parser(_build_parser(intent_name))
-        sub[domain] = engine
-
-    classify = _make_domain_classifier()
+            engine.register_intent_parser(_build_parser(intent_name),
+                                          domain=domain)
 
     results, latencies = [], []
     routed_ok = routed_total = 0
     for utt, expected in cases:
         t0 = time.perf_counter()
-        domain = classify(utt)
-        if domain in sub:
-            name, conf = _best_name(list(sub[domain].determine_intent(utt, 100)))
-        else:
-            name, conf = None, 0.0
+        intents = list(engine.determine_intent(utt, 100))
         latencies.append((time.perf_counter() - t0) * 1000)
-        results.append((name, conf))
+        results.append(_best_name(intents))
         if expected is not None:
             routed_total += 1
-            if domain == INTENT_DOMAIN.get(expected):
+            if engine.classify_domain(utt) == INTENT_DOMAIN.get(expected):
                 routed_ok += 1
 
     m = compute_metrics(results, cases)
-    print_report("hierarchical  —  two-stage (classify domain, then intent)",
+    print_report("hierarchical  —  HierarchicalIntentDeterminationEngine",
                  m, latencies)
     print(f"  Stage-1 routing : {routed_ok}/{routed_total} match cases "
           f"routed to the correct domain ({routed_ok / routed_total:.0%})")

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -63,7 +63,14 @@ def _entity_types(intent_names):
 
 
 #: intent_name -> its domain
-INTENT_DOMAIN = {i: d for d, names in DOMAINS.items() for i in names}
+INTENT_DOMAIN = {}
+for _domain, _names in DOMAINS.items():
+    for _intent in _names:
+        if _intent in INTENT_DOMAIN:
+            raise ValueError(
+                f"Intent '{_intent}' assigned to multiple domains: "
+                f"{INTENT_DOMAIN[_intent]} and {_domain}")
+        INTENT_DOMAIN[_intent] = _domain
 
 
 def _best_name(intents):
@@ -212,8 +219,9 @@ def run_hierarchical(cases):
     m = compute_metrics(results, cases)
     print_report("hierarchical  —  HierarchicalIntentDeterminationEngine",
                  m, latencies)
+    routed_pct = f"{routed_ok / routed_total:.0%}" if routed_total else "n/a"
     print(f"  Stage-1 routing : {routed_ok}/{routed_total} match cases "
-          f"routed to the correct domain ({routed_ok / routed_total:.0%})")
+          f"routed to the correct domain ({routed_pct})")
     return m, statistics.median(latencies), results
 
 

--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -1,0 +1,590 @@
+"""
+Keyword-intent benchmark dataset for the Adapt engine.
+
+Used to compare the flat ``IntentDeterminationEngine`` against the
+``DomainIntentDeterminationEngine`` on identical vocabulary and intents.
+
+Structure
+---------
+VOCAB
+    entity_type → list of entity_value strings that belong to that slot.
+    These are the words a skill would register via ``register_vocab``.
+
+INTENTS
+    intent_name → {"required": [entity_type, ...], "optional": [entity_type, ...]}
+    Mirrors what a skill sends via ``register_intent`` (IntentBuilder).
+
+DOMAINS
+    domain_name → list of intent_names grouped into that domain.
+    The domain engine registers each intent's parser and entities into its
+    domain's isolated sub-engine (separate Trie + tagger).
+
+TEST_CASES
+    List of (utterance, expected_intent_or_None).
+    Utterances are realistic natural-language phrasing that contains one or
+    more of the registered keywords.  They are NOT template fills — they
+    include filler words, contractions, politeness markers, and word-order
+    variation that real STT output produces.
+
+NO_MATCH_UTTERANCES
+    Utterances that share surface words with intents but should NOT match any.
+"""
+
+# ── vocabulary ─────────────────────────────────────────────────────────────
+
+VOCAB = {
+    # media
+    "PlayKeyword":      ["play", "put on", "start playing", "i want to hear",
+                         "listen to", "get some", "chuck on", "stick on"],
+    "StopKeyword":      ["stop", "pause", "halt", "cancel"],
+    "MusicKeyword":     ["music", "song", "track", "tunes", "playlist"],
+    "NextKeyword":      ["next", "skip", "forward"],
+    "VolumeKeyword":    ["volume", "louder", "quieter", "turn up", "turn down",
+                         "crank up", "ease off"],
+
+    # timers & alarms
+    "TimerKeyword":     ["timer", "countdown", "count down"],
+    "AlarmKeyword":     ["alarm", "wake me up", "wake me", "get me up"],
+    "SetKeyword":       ["set", "start", "create", "make"],
+    "CancelKeyword":    ["cancel", "delete", "remove", "stop", "turn off",
+                         "forget", "kill", "get rid of"],
+    "RemindKeyword":    ["remind me", "reminder", "don't let me forget",
+                         "nudge me", "don't forget", "put a reminder",
+                         "set a reminder", "i need to be reminded",
+                         "need to be reminded"],
+
+    # weather
+    "WeatherKeyword":   ["weather", "forecast", "temperature", "rain",
+                         "umbrella", "raining", "sunny", "cold", "hot", "warm",
+                         "conditions", "jacket", "coat"],
+
+    # smart home — lights
+    "LightKeyword":     ["light", "lights", "lighting"],
+    "OnKeyword":        ["on", "brighten", "turn on", "switch on", "flick on"],
+    "OffKeyword":       ["off", "turn off", "switch off", "dim", "flick off",
+                         "kill", "go dark", "lights out"],
+
+    # smart home — thermostat
+    "ThermostatKeyword": ["thermostat", "temperature", "heating", "heat",
+                          "cooling", "cool", "degrees"],
+    "HeatKeyword":      ["warmer", "warm", "hotter", "hot", "heat up",
+                         "turn up", "crank up", "freeze", "freezing"],
+    "CoolKeyword":      ["cooler", "cool", "cold", "cool down", "turn down",
+                         "boiling", "too hot"],
+
+    # communication
+    "CallKeyword":      ["call", "phone", "ring", "dial", "get on the line"],
+    "MessageKeyword":   ["message", "text", "send", "drop", "ping",
+                         "send a message", "shoot"],
+    "NoteKeyword":      ["note", "write", "jot", "take a note", "write down",
+                         "make a note", "note down"],
+
+    # shopping
+    "ShoppingKeyword":  ["shopping list", "shopping", "buy", "need",
+                         "add to the list", "put on the list", "out of",
+                         "running low on", "pick up", "running out"],
+    "ItemKeyword":      ["item", "product", "thing", "stuff"],
+
+    # information
+    "TimeKeyword":      ["time", "what time", "what's the time", "current time",
+                         "time check", "how late", "what hour"],
+    "DateKeyword":      ["date", "day", "today", "what day", "what month",
+                         "day of the week", "what's today"],
+    "SearchKeyword":    ["search", "look up", "google", "find", "search for",
+                         "what is", "what are"],
+
+    # navigation
+    "NavigateKeyword":  ["navigate", "directions", "route", "take me to",
+                         "drive to", "get me to", "how do i get to",
+                         "find a route", "direct me"],
+
+    # system
+    "HelpKeyword":      ["help", "what can you do", "capabilities",
+                         "list your skills", "what do you know", "commands"],
+    "StopCancelKeyword": ["stop", "cancel", "abort", "never mind", "forget it",
+                          "leave it", "don't bother", "scrap that"],
+}
+
+# ── intent definitions ─────────────────────────────────────────────────────
+
+INTENTS = {
+    "play_music": {
+        "required": ["PlayKeyword"],
+        "optional": ["MusicKeyword"],
+    },
+    "pause_music": {
+        "required": ["StopKeyword", "MusicKeyword"],
+        "optional": [],
+    },
+    "next_track": {
+        "required": ["NextKeyword"],
+        "optional": ["MusicKeyword"],
+    },
+    "set_volume": {
+        "required": ["VolumeKeyword"],
+        "optional": [],
+    },
+    "set_timer": {
+        "required": ["SetKeyword", "TimerKeyword"],
+        "optional": [],
+    },
+    "set_alarm": {
+        "required": ["AlarmKeyword"],
+        "optional": ["SetKeyword"],
+    },
+    "cancel_timer": {
+        "required": ["CancelKeyword", "TimerKeyword"],
+        "optional": [],
+    },
+    "weather_query": {
+        "required": ["WeatherKeyword"],
+        "optional": [],
+    },
+    "lights_on": {
+        "required": ["LightKeyword", "OnKeyword"],
+        "optional": [],
+    },
+    "lights_off": {
+        "required": ["LightKeyword", "OffKeyword"],
+        "optional": [],
+    },
+    "thermostat_set": {
+        "required": ["ThermostatKeyword"],
+        "optional": ["HeatKeyword", "CoolKeyword"],
+    },
+    "call_contact": {
+        "required": ["CallKeyword"],
+        "optional": [],
+    },
+    "send_message": {
+        "required": ["MessageKeyword"],
+        "optional": [],
+    },
+    "add_note": {
+        "required": ["NoteKeyword"],
+        "optional": [],
+    },
+    "add_shopping": {
+        "required": ["ShoppingKeyword"],
+        "optional": [],
+    },
+    "time_query": {
+        "required": ["TimeKeyword"],
+        "optional": [],
+    },
+    "date_query": {
+        "required": ["DateKeyword"],
+        "optional": [],
+    },
+    "search_query": {
+        "required": ["SearchKeyword"],
+        "optional": [],
+    },
+    "navigate_to": {
+        "required": ["NavigateKeyword"],
+        "optional": [],
+    },
+    "help": {
+        "required": ["HelpKeyword"],
+        "optional": [],
+    },
+    "stop": {
+        "required": ["StopCancelKeyword"],
+        "optional": [],
+    },
+    "add_reminder": {
+        "required": ["RemindKeyword"],
+        "optional": [],
+    },
+}
+
+# ── domain grouping ────────────────────────────────────────────────────────
+# Semantically related intents grouped into domains. The domain engine gives
+# each domain its own isolated sub-engine (separate Trie + entity tagger).
+
+DOMAINS = {
+    "media":         ["play_music", "pause_music", "next_track", "set_volume"],
+    "timers_alarms": ["set_timer", "set_alarm", "cancel_timer", "add_reminder"],
+    "weather":       ["weather_query"],
+    "lights":        ["lights_on", "lights_off"],
+    "climate":       ["thermostat_set"],
+    "communication": ["call_contact", "send_message", "add_note"],
+    "shopping":      ["add_shopping"],
+    "information":   ["time_query", "date_query", "search_query"],
+    "navigation":    ["navigate_to"],
+    "system":        ["help", "stop"],
+}
+
+# ── labelled test utterances ───────────────────────────────────────────────
+
+TEST_CASES = [
+    # play_music
+    ("play some jazz please",               "play_music"),
+    ("put on some background music",        "play_music"),
+    ("i want to hear something calm",       "play_music"),
+    ("can you play the beatles",            "play_music"),
+    ("chuck on a playlist",                 "play_music"),
+    ("start playing something upbeat",      "play_music"),
+    ("stick on some tunes",                 "play_music"),
+    ("get some lo-fi going",                "play_music"),
+    ("listen to pink floyd",                "play_music"),
+    ("play that song i like",               "play_music"),
+
+    # pause_music
+    ("pause the music",                     "pause_music"),
+    ("stop the track",                      "pause_music"),
+    ("pause that song for a moment",        "pause_music"),
+    ("can you stop the music please",       "pause_music"),
+    ("halt the music",                      "pause_music"),
+
+    # next_track
+    ("next track please",                   "next_track"),
+    ("skip this song",                      "next_track"),
+    ("skip to the next one",                "next_track"),
+    ("next please",                         "next_track"),
+    ("skip forward a track",                "next_track"),
+
+    # set_volume
+    ("volume up please",                    "set_volume"),
+    ("make it louder",                      "set_volume"),
+    ("turn it down a bit",                  "set_volume"),
+    ("could you turn the volume down",      "set_volume"),
+    ("crank up the volume",                 "set_volume"),
+    ("volume quieter please",               "set_volume"),
+
+    # set_timer
+    ("set a timer please",                  "set_timer"),
+    ("can you set a timer for five minutes", "set_timer"),
+    ("start a countdown",                   "set_timer"),
+    ("make a ten minute timer",             "set_timer"),
+    ("create a timer for half an hour",     "set_timer"),
+
+    # set_alarm
+    ("wake me up at seven",                 "set_alarm"),
+    ("set an alarm for six thirty",         "set_alarm"),
+    ("i need an alarm",                     "set_alarm"),
+    ("wake me tomorrow morning",            "set_alarm"),
+    ("get me up at six",                    "set_alarm"),
+
+    # cancel_timer
+    ("cancel the timer",                    "cancel_timer"),
+    ("stop the timer",                      "cancel_timer"),
+    ("delete the countdown",                "cancel_timer"),
+    ("get rid of the timer",                "cancel_timer"),
+    ("turn off the timer",                  "cancel_timer"),
+
+    # weather_query
+    ("what's the weather like today",       "weather_query"),
+    ("do i need an umbrella",               "weather_query"),
+    ("is it going to rain",                 "weather_query"),
+    ("should i bring a coat",               "weather_query"),
+    ("how cold is it outside",              "weather_query"),
+    ("what's the forecast",                 "weather_query"),
+    ("is it sunny today",                   "weather_query"),
+    ("what's the temperature",              "weather_query"),
+
+    # lights_on
+    ("turn the lights on please",           "lights_on"),
+    ("lights on",                           "lights_on"),
+    ("switch on the lights",                "lights_on"),
+    ("can you flick on the lights",         "lights_on"),
+    ("brighten the lights up",              "lights_on"),
+
+    # lights_off
+    ("turn the lights off",                 "lights_off"),
+    ("lights off please",                   "lights_off"),
+    ("switch off the lights",               "lights_off"),
+    ("dim the lights",                      "lights_off"),
+    ("go dark",                             "lights_off"),
+    ("kill the lights",                     "lights_off"),
+
+    # thermostat_set
+    ("set the thermostat",                  "thermostat_set"),
+    ("adjust the heating",                  "thermostat_set"),
+    ("it's freezing turn the heating up",   "thermostat_set"),
+    ("can you cool it down",                "thermostat_set"),
+    ("make it warmer in here",              "thermostat_set"),
+    ("change the temperature please",       "thermostat_set"),
+
+    # call_contact
+    ("call alice please",                   "call_contact"),
+    ("ring dad",                            "call_contact"),
+    ("phone the office",                    "call_contact"),
+    ("dial charlie",                        "call_contact"),
+    ("can you get sarah on the line",       "call_contact"),
+
+    # send_message
+    ("send a message to alice",             "send_message"),
+    ("text john please",                    "send_message"),
+    ("drop bob a message",                  "send_message"),
+    ("ping sarah",                          "send_message"),
+    ("shoot charlie a text",                "send_message"),
+
+    # add_note
+    ("take a note",                         "add_note"),
+    ("write this down",                     "add_note"),
+    ("make a note of that",                 "add_note"),
+    ("jot this down please",                "add_note"),
+    ("note that the meeting moved",         "add_note"),
+
+    # add_shopping
+    ("add milk to the shopping list",       "add_shopping"),
+    ("put bread on the shopping list",      "add_shopping"),
+    ("we need to buy coffee",               "add_shopping"),
+    ("running low on eggs",                 "add_shopping"),
+    ("pick up some cheese",                 "add_shopping"),
+    ("out of washing up liquid",            "add_shopping"),
+
+    # time_query
+    ("what time is it",                     "time_query"),
+    ("what's the time",                     "time_query"),
+    ("current time please",                 "time_query"),
+    ("time check",                          "time_query"),
+    ("how late is it",                      "time_query"),
+    ("what hour is it",                     "time_query"),
+
+    # date_query
+    ("what day is it today",                "date_query"),
+    ("what's today's date",                 "date_query"),
+    ("what month are we in",                "date_query"),
+    ("what day of the week is it",          "date_query"),
+    ("is today a monday",                   "date_query"),
+
+    # search_query
+    ("search for the nearest pharmacy",     "search_query"),
+    ("look up sourdough recipe",            "search_query"),
+    ("google how to fix a leak",            "search_query"),
+    ("find a good pizza place",             "search_query"),
+    ("what is photosynthesis",              "search_query"),
+    ("what are the symptoms of a cold",     "search_query"),
+
+    # navigate_to
+    ("navigate to the airport",             "navigate_to"),
+    ("get directions to the hospital",      "navigate_to"),
+    ("take me to the station",              "navigate_to"),
+    ("how do i get to the city centre",     "navigate_to"),
+    ("find a route to the supermarket",     "navigate_to"),
+    ("get me to work please",               "navigate_to"),
+
+    # help
+    ("help",                                "help"),
+    ("what can you do",                     "help"),
+    ("list your skills please",             "help"),
+    ("show me your capabilities",           "help"),
+    ("what commands do you know",           "help"),
+
+    # stop
+    ("stop",                                "stop"),
+    ("cancel that",                         "stop"),
+    ("never mind",                          "stop"),
+    ("forget it",                           "stop"),
+    ("abort",                               "stop"),
+    ("scrap that",                          "stop"),
+    ("leave it",                            "stop"),
+    ("don't bother",                        "stop"),
+
+    # ── harder cases: keyword present but embedded in longer phrasing ──────
+    ("can you turn the volume up a bit please",      "set_volume"),
+    ("it is way too loud in here turn it down",      "set_volume"),
+    ("do me a favour and ring my dad",               "call_contact"),
+    ("go ahead and navigate me to the supermarket",  "navigate_to"),
+    ("i think we need to buy some milk actually",    "add_shopping"),
+    ("can you just search for the nearest chemist",  "search_query"),
+    ("set a ten minute timer would you",             "set_timer"),
+    ("could you wake me up at half six tomorrow",    "set_alarm"),
+    ("what's the weather going to be like tomorrow", "weather_query"),
+    ("can someone tell me what time it is",          "time_query"),
+    ("go on then cancel the timer",                  "cancel_timer"),
+    ("lights please turn them on",                   "lights_on"),
+    ("flip the lights off would you",                "lights_off"),
+    ("can you look up what the capital of france is","search_query"),
+    ("dial my brother's number",                     "call_contact"),
+    ("drop sarah a quick text saying i'm on my way", "send_message"),
+    ("jot this down the meeting is at three",        "add_note"),
+    ("add bananas and milk to the shopping please",  "add_shopping"),
+    ("get directions to the nearest hospital",       "navigate_to"),
+    ("give me a hand what day is it today",          "date_query"),
+
+    # ── ambiguous phrasing (correct intent requires keyword disambiguation) ─
+    ("the temperature please",                       "weather_query"),
+    ("it's really cold outside",                     "weather_query"),
+    ("turn the heating up a few degrees",            "thermostat_set"),
+    ("skip to the next track please",                "next_track"),
+    ("i need to be reminded to call the dentist",    "add_reminder"),
+    ("put a reminder on for my doctor's appointment","add_reminder"),
+
+    # ── short utterances (1–3 words) ──────────────────────────────────────
+    ("play",                    "play_music"),
+    ("pause the music",             "pause_music"),
+    ("next",                    "next_track"),
+    ("louder",                  "set_volume"),
+    ("quieter",                 "set_volume"),
+    ("timer",                   "set_timer"),
+    ("cancel",                  "stop"),
+    ("navigate",                "navigate_to"),
+    ("search",                  "search_query"),
+    ("lights on",               "lights_on"),
+    ("lights off",              "lights_off"),
+    ("time please",             "time_query"),
+    ("what day",                "date_query"),
+    ("call mum",                "call_contact"),
+    ("text alice",              "send_message"),
+    ("write this",              "add_note"),
+    ("buy milk",                "add_shopping"),
+    ("wake me",                 "set_alarm"),
+    ("the weather",             "weather_query"),
+
+    # ── medium utterances (4–8 words) ────────────────────────────────────
+    ("skip this i don't like it",                   "next_track"),
+    ("how warm is it today",                        "weather_query"),
+    ("remind me about the meeting",                 "add_reminder"),
+    ("send bob a quick message",                    "send_message"),
+    ("turn up the volume a bit",                    "set_volume"),
+    ("what time does the sun set",                  "time_query"),
+    ("look up the bus timetable",                   "search_query"),
+    ("put a timer on for lunch",                    "set_timer"),
+    ("phone my sister in law",                      "call_contact"),
+    ("write down eggs butter flour",                "add_note"),
+    ("get directions to the station",               "navigate_to"),
+    ("turn the heating down a bit",                 "thermostat_set"),
+    ("add bread to shopping list",                  "add_shopping"),
+    ("set an alarm for six am",                     "set_alarm"),
+    ("switch the bathroom light on",                "lights_on"),
+    ("can you stop the current song",               "pause_music"),
+
+    # ── long utterances (9–14 words) ─────────────────────────────────────
+    ("i was wondering if you could look up how to make pasta carbonara",   "search_query"),
+    ("do you think you could turn the music down just a little bit please","set_volume"),
+    ("i need you to set a reminder so i don't forget to take my tablets",  "add_reminder"),
+    ("could you get directions to the nearest petrol station from here",   "navigate_to"),
+    ("i'd really appreciate it if you could turn the lights off in here",  "lights_off"),
+    ("before i go to bed can you set an alarm for half past six tomorrow", "set_alarm"),
+    ("actually you know what just cancel that ignore everything i said",   "stop"),
+    ("is it going to be warm enough to go outside without a coat today",   "weather_query"),
+    ("can you put oat milk and a dozen eggs on the shopping list for me",  "add_shopping"),
+    ("i need to call the doctor's surgery can you dial them for me please","call_contact"),
+    ("write this down i owe sarah twenty quid for the cinema last night",  "add_note"),
+    ("set a five minute countdown so i know when to take the pasta off",   "set_timer"),
+    ("let me know what time it is i've completely lost track of the day",  "time_query"),
+    ("is there any chance you could bump the thermostat up a few degrees", "thermostat_set"),
+    ("can you skip this track i've heard it about a hundred times already","next_track"),
+
+    # ── very long utterances (15+ words) ─────────────────────────────────
+    ("i know this is a bit of a long one but could you please navigate me to the shopping centre on the high street", "navigate_to"),
+    ("i'm running a bit late and i was wondering if you could send a message to alice letting her know i'll be there in about twenty minutes", "send_message"),
+    ("look i really don't want to forget this so could you please write it down somewhere the pin for my new card is one two three four", "add_note"),
+    ("i've been trying to remember all morning what time my dentist appointment is and i just cannot work it out can you look it up for me", "search_query"),
+    ("the music is absolutely lovely but honestly it is just a tiny little bit too loud for me right now so could you turn it down please", "set_volume"),
+    ("it's been a really long week and i just want to relax so could you put on something calm and peaceful to listen to in the background", "play_music"),
+    ("i need to be up early tomorrow for a really important meeting so could you set an alarm for six o'clock in the morning without fail please", "set_alarm"),
+    ("before we head out i want to make sure the lights are all switched off so could you please go ahead and turn them all off right now", "lights_off"),
+
+    # ── multi-intent queries: two intents' keywords both present ──────────
+    # The labelled intent is the one a parser should prefer (higher coverage /
+    # more required slots matched).  These stress-test disambiguation logic.
+    ("stop the music and cancel my alarm",
+     "pause_music"),       # StopKeyword+MusicKeyword outranks cancel alone
+    ("turn off the lights and set a timer for ten minutes",
+     "set_timer"),         # primary intent is setting a timer
+    ("skip this song and turn it up",
+     "next_track"),        # next_track keyword more specific than volume alone
+    ("call alice and remind her about the meeting",
+     "call_contact"),      # CallKeyword direct; remind surfaces as optional
+    ("what time is it and what's the weather like",
+     "time_query"),        # time_query slots dominate in this ordering
+    ("search for pizza places and navigate to the best one",
+     "navigate_to"),       # navigate has stronger required-keyword coverage
+    ("set a timer and remind me to check it",
+     "add_reminder"),      # remind slot wins; set+timer covered but remind more specific
+    ("send a message to bob and add milk to the shopping list",
+     "send_message"),      # MessageKeyword direct match wins
+    ("cancel the alarm and never mind the timer",
+     "stop"),              # StopCancelKeyword matches "never mind"; cancel alone fires stop
+    ("pause the music and turn down the volume",
+     "set_volume"),        # VolumeKeyword+DirectionKeyword outranks pause_music coverage
+]
+
+# ── no-match utterances ────────────────────────────────────────────────────
+# Includes both easy (no keyword overlap) and hard (surface keyword present
+# but not a command) cases to stress-test false-positive rate.
+
+NO_MATCH_UTTERANCES = [
+    # ── easy: conversational / off-topic — no keyword overlap ────────────────
+    "um yeah so anyway",
+    "right okay then",
+    "hmm not sure about that",
+    "oh interesting",
+    "fair enough",
+    "the dog ate my homework",
+    "i've been thinking about getting a new sofa",
+    "did you see the match last night",
+    "my knee's been giving me trouble",
+    "i went to the dentist yesterday",
+    "what a lovely afternoon it is",
+    "i really fancy a cup of tea",
+    "the cat's been acting strange all week",
+    "that film last night was brilliant",
+    "i can't believe how fast the year's gone",
+    "my back's been killing me since tuesday",
+
+    # ── single keyword present but not a command ──────────────────────────────
+    "my friend alice rang me earlier",             # 'ring' ∈ CallKeyword
+    "the music at that restaurant was terrible",   # 'music' ∈ MusicKeyword
+    "i watched a documentary about the weather",   # 'weather' ∈ WeatherKeyword
+    "the lights were beautiful at the concert",    # 'lights' ∈ LightKeyword (no on/off)
+    "the alarm woke the whole street",             # 'alarm' ∈ AlarmKeyword
+    "my shopping bag broke",                       # 'shopping' ∈ ShoppingKeyword
+    "the timer on the oven is broken",             # 'timer' ∈ TimerKeyword
+    "i always stop for coffee in the morning",     # 'stop' ∈ StopKeyword
+    "she left me a note on the table",             # 'note' ∈ NoteKeyword
+    "the day was long",                            # 'day' ∈ DateKeyword
+    "he could navigate by the stars",              # 'navigate' ∈ NavigateKeyword
+    "she sent a text to her mum",                  # 'text'+'send' — past tense report
+    "the play was set in the victorian era",       # 'set' ∈ SetKeyword
+    "we need more people like her",                # 'need' ∈ ShoppingKeyword
+    "the volume of complaints has gone up",        # 'volume' ∈ VolumeKeyword — noun
+    "the track record speaks for itself",          # 'track' ∈ MusicKeyword — idiom
+    "i find that hard to believe",                 # 'find' ∈ SearchKeyword — not a search
+    "next time i'll remember",                     # 'next' ∈ NextKeyword — temporal not skip
+    "the forecast was wrong again",                # 'forecast' ∈ WeatherKeyword — report
+    "they called an emergency meeting",            # 'called' ∈ CallKeyword — past tense
+
+    # ── multiple keywords present, still not a command ────────────────────────
+    "the weather alarm went off at six",           # 'weather'+'alarm' — description
+    "i need to buy some time",                     # 'buy'+'time' — idiom
+    "call it a day",                               # 'call'+'day' — idiom
+    "stop and note the temperature outside",       # many keywords — observation
+    "the lights went out and the alarm sounded",   # passive, not a command
+    "i sent a message about the shopping list",    # 'message'+'shopping' — past tense
+    "ring the timer when the alarm goes off",      # 'ring'+'timer'+'alarm' — description
+    "the forecast says it will be cold tomorrow",  # 'weather' paraphrase, not a query
+    "turn it up was the band's best album",        # 'turn up' ∈ VolumeKeyword — not a command
+    "she set the timer and then went to bed",      # past tense narrative
+    "the note said to call him back by noon",      # 'note'+'call' — reporting, not commands
+    "they found the route on an old map",          # 'found'+'route' — narrative
+    "he wrote down the directions to the shop",    # 'write'+'directions' — past tense
+    "we get the alarm serviced every year",        # 'alarm' in factual context
+    "the shopping channel was on all night",       # 'shopping' — noun, not list command
+
+    # ── rhetorical / hypothetical — sound like commands but aren't ───────────
+    "what would you do if the lights went out",    # conditional question
+    "wouldn't it be nice to skip all the boring bits", # hypothetical, not a skip command
+    "who even sets an alarm on a saturday",        # rhetorical
+    "can you believe they cancelled the gig",      # 'cancel' — rhetorical question
+    "imagine if you could just turn down the noise", # hypothetical
+    "do you think it will rain at the weekend",    # opinion question, not weather command
+    "i wonder what the time is in new york",       # musing, not a time query command
+
+    # ── third-person / reported speech — describing others' actions ───────────
+    "she asked him to call her back later",        # 'call' — reported request
+    "they said the music was too loud at the party", # 'music' — reported complaint
+    "my mum always sets three alarms just in case", # 'alarms' — describing habit
+    "the kids wanted to play something different",  # 'play' — not a media command
+
+    # ── nonsense ──────────────────────────────────────────────────────────────
+    "blarg wump fizz",
+    "one fish two fish red fish blue fish",
+    "supercalifragilistic",
+    "lorem ipsum dolor sit amet",
+    "the mitochondria is the powerhouse of the cell",
+]

--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -50,7 +50,9 @@ VOCAB = {
                       "podcast", "tune"],
     "OBJ_LIGHT":     ["light", "lights", "lamp", "bulb", "lighting"],
     "OBJ_HVAC":      ["thermostat", "heating", "heater", "radiator",
-                      "air conditioning"],
+                      "air conditioning", "temperature"],
+    "OBJ_ROOM":      ["bedroom", "kitchen", "living room", "bathroom",
+                      "hallway", "office", "garage"],
     "OBJ_TIMER":     ["timer", "countdown"],
     "OBJ_ALARM":     ["alarm"],
     "OBJ_WEATHER":   ["weather", "forecast", "rain", "umbrella",
@@ -77,11 +79,15 @@ INTENTS = {
     "volume_up":     {"required": ["ACTION_RAISE", "OBJ_AUDIO"], "optional": []},
     "volume_down":   {"required": ["ACTION_LOWER", "OBJ_AUDIO"], "optional": []},
     # lights
-    "lights_on":     {"required": ["ACTION_ON", "OBJ_LIGHT"], "optional": []},
-    "lights_off":    {"required": ["ACTION_OFF", "OBJ_LIGHT"], "optional": []},
+    "lights_on":     {"required": ["ACTION_ON", "OBJ_LIGHT"],
+                      "optional": ["OBJ_ROOM"]},
+    "lights_off":    {"required": ["ACTION_OFF", "OBJ_LIGHT"],
+                      "optional": ["OBJ_ROOM"]},
     # climate
-    "heating_up":    {"required": ["ACTION_RAISE", "OBJ_HVAC"], "optional": []},
-    "heating_down":  {"required": ["ACTION_LOWER", "OBJ_HVAC"], "optional": []},
+    "heating_up":    {"required": ["ACTION_RAISE", "OBJ_HVAC"],
+                      "optional": ["OBJ_ROOM"]},
+    "heating_down":  {"required": ["ACTION_LOWER", "OBJ_HVAC"],
+                      "optional": ["OBJ_ROOM"]},
     "check_hvac":    {"required": ["ACTION_ASK", "OBJ_HVAC"], "optional": []},
     # timers & alarms
     "set_timer":     {"required": ["ACTION_SET", "OBJ_TIMER"], "optional": []},
@@ -226,7 +232,7 @@ TEST_CASES = [
     ("do i need an umbrella",                 "weather_query"),
     ("what's the forecast",                   "weather_query"),
     ("is there snow coming",                  "weather_query"),
-    ("what's the temperature outside",        "weather_query"),
+    ("is it going to snow",                   "weather_query"),
 
     # add_reminder — OBJ_REMINDER
     ("set a reminder",                        "add_reminder"),
@@ -236,7 +242,7 @@ TEST_CASES = [
 
     # call_contact — OBJ_PHONE
     ("call mum",                              "call_contact"),
-    ("phone the office",                      "call_contact"),
+    ("phone the bank",                        "call_contact"),
     ("dial charlie",                          "call_contact"),
     ("ring my brother",                       "call_contact"),
 
@@ -314,6 +320,33 @@ TEST_CASES = [
     ("turn off the lights then call mum",     "lights_off"),
     ("write a note about the shopping",       "add_note"),
     ("set a timer for the laundry",           "set_timer"),
+
+    # ── discriminating: flat & domain win, hierarchical loses ─────────────
+    # Real single-intent commands. The OBJECT keyword is unambiguous, but the
+    # utterance also carries a long room/topic word that pulls the stage-1
+    # coverage classifier to the wrong domain; the misroute is unrecoverable.
+    # One-word commands give the classifier nothing to route on at all.
+    ("play music in the living room",         "play_music"),
+    ("turn up the volume in the bedroom",     "volume_up"),
+    ("call mum about the heating",            "call_contact"),
+    ("set a timer in the living room",        "set_timer"),
+    ("look up the temperature",               "search_query"),
+    ("google the heating thermostat",         "search_query"),
+    ("the temperature please",                "weather_query"),
+    ("stop the timer",                        "stop_all"),
+
+    # ── discriminating: flat and domain diverge ───────────────────────────
+    # Two-clause utterances carrying two intents. Labelled by the leading
+    # clause. Flat scores every parser against one shared clique; domain
+    # scores each clause in its own isolated sub-engine. Because adapt
+    # confidence divides each intent's score by the total tag count of its
+    # clique, the two topologies break the tie between clauses differently.
+    ("turn off the lights and stop the music",   "lights_off"),
+    ("turn up the heating and lower the volume", "heating_up"),
+    ("turn on the lights and pause the music",   "lights_on"),
+    ("play some music and turn on the lights",   "play_music"),
+    ("lower the heating and pause the music",    "heating_down"),
+    ("play a podcast and turn down the heating", "play_music"),
 ]
 
 # ── no-match utterances ────────────────────────────────────────────────────
@@ -378,4 +411,21 @@ NO_MATCH_UTTERANCES = [
     "one fish two fish red fish",
     "lorem ipsum dolor sit amet",
     "the mitochondria is the powerhouse of the cell",
+
+    # ── discriminating: hierarchical wins, flat & domain lose ─────────────
+    # Not commands, but each contains a bare keyword for a single-slot intent
+    # (stop_all). Flat and domain fire stop_all on the lone word. The stage-1
+    # classifier routes these to a two-slot domain (media or timers) whose
+    # intents need a second keyword that is absent, so nothing fires and no
+    # false positive is emitted.
+    "they cancel each other out",
+    "they never stop arguing",
+    "the bus stop was crowded",
+    "cancel culture is everywhere",
+    "we should cancel the trip",
+    "i had to cancel my plans",
+    "stop right there",
+    "they would not stop talking",
+    "the train made a quick stop",
+    "the cancel button was greyed out",
 ]

--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -1,656 +1,381 @@
 """
 Keyword-intent benchmark dataset for the Adapt engine.
 
-Used to compare the flat ``IntentDeterminationEngine`` against the
-``DomainIntentDeterminationEngine`` on identical vocabulary and intents.
+Used to compare three engine topologies on identical vocabulary and intents:
+the flat ``IntentDeterminationEngine``, the parallel
+``DomainIntentDeterminationEngine``, and a two-stage hierarchical router.
+
+Design
+------
+Intents are mostly **two-slot** — an ACTION keyword plus an OBJECT keyword —
+so a single stray keyword does not trigger an intent on its own. OBJECT
+vocabularies are domain-distinctive (``thermostat`` only ever appears in
+*climate*, ``playlist`` only in *media*), which lets a domain classifier
+route reliably. ACTION vocabularies are deliberately shared across domains
+(``turn up`` is both a volume and a heating action), so disambiguation
+depends on the object — the case that separates the engine topologies.
+
+A handful of intents are genuinely single-trigger (``weather_query``,
+``get_help``, ``navigate_to``) and stay one-slot.
 
 Structure
 ---------
-VOCAB
-    entity_type → list of entity_value strings that belong to that slot.
-    These are the words a skill would register via ``register_vocab``.
-
-INTENTS
-    intent_name → {"required": [entity_type, ...], "optional": [entity_type, ...]}
-    Mirrors what a skill sends via ``register_intent`` (IntentBuilder).
-
-DOMAINS
-    domain_name → list of intent_names grouped into that domain.
-    The domain engine registers each intent's parser and entities into its
-    domain's isolated sub-engine (separate Trie + tagger).
-
-TEST_CASES
-    List of (utterance, expected_intent_or_None).
-    Utterances are realistic natural-language phrasing that contains one or
-    more of the registered keywords.  They are NOT template fills — they
-    include filler words, contractions, politeness markers, and word-order
-    variation that real STT output produces.
-
-NO_MATCH_UTTERANCES
-    Utterances that share surface words with intents but should NOT match any.
+VOCAB       entity_type -> [entity_value, ...]   (ACTION_* and OBJ_* groups)
+INTENTS     intent_name -> {"required": [...], "optional": [...]}
+DOMAINS     domain_name -> [intent_name, ...]
+TEST_CASES  [(utterance, expected_intent), ...]
+NO_MATCH_UTTERANCES   [utterance, ...]   (should match nothing)
 """
 
-# ── vocabulary ─────────────────────────────────────────────────────────────
+# ── action vocabulary (shared across domains) ──────────────────────────────
 
 VOCAB = {
-    # media
-    "PlayKeyword":      ["play", "put on", "start playing", "i want to hear",
-                         "listen to", "get some", "chuck on", "stick on"],
-    "StopKeyword":      ["stop", "pause", "halt", "cancel"],
-    "MusicKeyword":     ["music", "song", "track", "tunes", "playlist"],
-    "NextKeyword":      ["next", "skip", "forward"],
-    "VolumeKeyword":    ["volume", "louder", "quieter", "turn up", "turn down",
-                         "crank up", "ease off"],
+    "ACTION_PLAY":   ["play", "put on", "queue"],
+    "ACTION_STOP":   ["stop", "pause", "halt"],
+    "ACTION_SKIP":   ["next", "skip"],
+    "ACTION_RAISE":  ["turn up", "crank up", "raise", "increase"],
+    "ACTION_LOWER":  ["turn down", "lower", "decrease"],
+    "ACTION_ON":     ["turn on", "switch on", "enable"],
+    "ACTION_OFF":    ["turn off", "switch off", "disable"],
+    "ACTION_SET":    ["set", "create", "make", "schedule", "start"],
+    "ACTION_CANCEL": ["cancel", "delete", "remove", "clear"],
+    "ACTION_ASK":    ["what", "how", "tell me", "check", "give me"],
+    "ACTION_SEND":   ["send", "write", "jot down", "leave", "draft"],
+    "ACTION_GO":     ["navigate to", "take me to", "drive to",
+                      "directions to", "get me to"],
 
-    # timers & alarms
-    "TimerKeyword":     ["timer", "countdown", "count down"],
-    "AlarmKeyword":     ["alarm", "wake me up", "wake me", "get me up"],
-    "SetKeyword":       ["set", "start", "create", "make"],
-    "CancelKeyword":    ["cancel", "delete", "remove", "stop", "turn off",
-                         "forget", "kill", "get rid of"],
-    "RemindKeyword":    ["remind me", "reminder", "don't let me forget",
-                         "nudge me", "don't forget", "put a reminder",
-                         "set a reminder", "i need to be reminded",
-                         "need to be reminded"],
-
-    # weather
-    "WeatherKeyword":   ["weather", "forecast", "temperature", "rain",
-                         "umbrella", "raining", "sunny", "cold", "hot", "warm",
-                         "conditions", "jacket", "coat"],
-
-    # smart home — lights
-    "LightKeyword":     ["light", "lights", "lighting"],
-    "OnKeyword":        ["on", "brighten", "turn on", "switch on", "flick on"],
-    "OffKeyword":       ["off", "turn off", "switch off", "dim", "flick off",
-                         "kill", "go dark", "lights out"],
-
-    # smart home — thermostat
-    "ThermostatKeyword": ["thermostat", "temperature", "heating", "heat",
-                          "cooling", "cool", "degrees"],
-    "HeatKeyword":      ["warmer", "warm", "hotter", "hot", "heat up",
-                         "turn up", "crank up", "freeze", "freezing"],
-    "CoolKeyword":      ["cooler", "cool", "cold", "cool down", "turn down",
-                         "boiling", "too hot"],
-
-    # communication
-    "CallKeyword":      ["call", "phone", "ring", "dial", "get on the line"],
-    "MessageKeyword":   ["message", "text", "send", "drop", "ping",
-                         "send a message", "shoot"],
-    "NoteKeyword":      ["note", "write", "jot", "take a note", "write down",
-                         "make a note", "note down"],
-
-    # shopping
-    "ShoppingKeyword":  ["shopping list", "shopping", "buy", "need",
-                         "add to the list", "put on the list", "out of",
-                         "running low on", "pick up", "running out"],
-    "ItemKeyword":      ["item", "product", "thing", "stuff"],
-
-    # information
-    "TimeKeyword":      ["time", "what time", "what's the time", "current time",
-                         "time check", "how late", "what hour"],
-    "DateKeyword":      ["date", "day", "today", "what day", "what month",
-                         "day of the week", "what's today"],
-    "SearchKeyword":    ["search", "look up", "google", "find", "search for",
-                         "what is", "what are"],
-
-    # navigation
-    "NavigateKeyword":  ["navigate", "directions", "route", "take me to",
-                         "drive to", "get me to", "how do i get to",
-                         "find a route", "direct me"],
-
-    # system
-    "HelpKeyword":      ["help", "what can you do", "capabilities",
-                         "list your skills", "what do you know", "commands"],
-    "StopCancelKeyword": ["stop", "cancel", "abort", "never mind", "forget it",
-                          "leave it", "don't bother", "scrap that"],
+    # ── object vocabulary (domain-distinctive) ─────────────────────────────
+    "OBJ_AUDIO":     ["volume", "sound", "music", "song", "stereo"],
+    "OBJ_MUSIC":     ["music", "song", "track", "playlist", "album",
+                      "podcast", "tune"],
+    "OBJ_LIGHT":     ["light", "lights", "lamp", "bulb", "lighting"],
+    "OBJ_HVAC":      ["thermostat", "heating", "heater", "radiator",
+                      "air conditioning"],
+    "OBJ_TIMER":     ["timer", "countdown"],
+    "OBJ_ALARM":     ["alarm"],
+    "OBJ_WEATHER":   ["weather", "forecast", "rain", "umbrella",
+                      "temperature", "snow"],
+    "OBJ_REMINDER":  ["reminder", "remind me"],
+    "OBJ_PHONE":     ["call", "phone", "dial", "ring"],
+    "OBJ_MESSAGE":   ["message", "text", "email"],
+    "OBJ_NOTE":      ["note", "memo"],
+    "OBJ_SHOPPING":  ["shopping list", "groceries", "shopping"],
+    "OBJ_TIME":      ["time", "clock"],
+    "OBJ_DATE":      ["date", "today", "what day"],
+    "OBJ_SEARCH":    ["search", "look up", "google"],
+    "OBJ_HELP":      ["help", "commands"],
+    "OBJ_HALT":      ["stop", "cancel", "abort", "never mind"],
 }
 
 # ── intent definitions ─────────────────────────────────────────────────────
 
 INTENTS = {
-    "play_music": {
-        "required": ["PlayKeyword"],
-        "optional": ["MusicKeyword"],
-    },
-    "pause_music": {
-        "required": ["StopKeyword", "MusicKeyword"],
-        "optional": [],
-    },
-    "next_track": {
-        "required": ["NextKeyword"],
-        "optional": ["MusicKeyword"],
-    },
-    "set_volume": {
-        "required": ["VolumeKeyword"],
-        "optional": [],
-    },
-    "set_timer": {
-        "required": ["SetKeyword", "TimerKeyword"],
-        "optional": [],
-    },
-    "set_alarm": {
-        "required": ["AlarmKeyword"],
-        "optional": ["SetKeyword"],
-    },
-    "cancel_timer": {
-        "required": ["CancelKeyword", "TimerKeyword"],
-        "optional": [],
-    },
-    "weather_query": {
-        "required": ["WeatherKeyword"],
-        "optional": [],
-    },
-    "lights_on": {
-        "required": ["LightKeyword", "OnKeyword"],
-        "optional": [],
-    },
-    "lights_off": {
-        "required": ["LightKeyword", "OffKeyword"],
-        "optional": [],
-    },
-    "thermostat_set": {
-        "required": ["ThermostatKeyword"],
-        "optional": ["HeatKeyword", "CoolKeyword"],
-    },
-    "call_contact": {
-        "required": ["CallKeyword"],
-        "optional": [],
-    },
-    "send_message": {
-        "required": ["MessageKeyword"],
-        "optional": [],
-    },
-    "add_note": {
-        "required": ["NoteKeyword"],
-        "optional": [],
-    },
-    "add_shopping": {
-        "required": ["ShoppingKeyword"],
-        "optional": [],
-    },
-    "time_query": {
-        "required": ["TimeKeyword"],
-        "optional": [],
-    },
-    "date_query": {
-        "required": ["DateKeyword"],
-        "optional": [],
-    },
-    "search_query": {
-        "required": ["SearchKeyword"],
-        "optional": [],
-    },
-    "navigate_to": {
-        "required": ["NavigateKeyword"],
-        "optional": [],
-    },
-    "help": {
-        "required": ["HelpKeyword"],
-        "optional": [],
-    },
-    "stop": {
-        "required": ["StopCancelKeyword"],
-        "optional": [],
-    },
-    "add_reminder": {
-        "required": ["RemindKeyword"],
-        "optional": [],
-    },
+    # media
+    "play_music":    {"required": ["ACTION_PLAY", "OBJ_MUSIC"], "optional": []},
+    "pause_music":   {"required": ["ACTION_STOP", "OBJ_MUSIC"], "optional": []},
+    "next_track":    {"required": ["ACTION_SKIP"], "optional": ["OBJ_MUSIC"]},
+    "volume_up":     {"required": ["ACTION_RAISE", "OBJ_AUDIO"], "optional": []},
+    "volume_down":   {"required": ["ACTION_LOWER", "OBJ_AUDIO"], "optional": []},
+    # lights
+    "lights_on":     {"required": ["ACTION_ON", "OBJ_LIGHT"], "optional": []},
+    "lights_off":    {"required": ["ACTION_OFF", "OBJ_LIGHT"], "optional": []},
+    # climate
+    "heating_up":    {"required": ["ACTION_RAISE", "OBJ_HVAC"], "optional": []},
+    "heating_down":  {"required": ["ACTION_LOWER", "OBJ_HVAC"], "optional": []},
+    "check_hvac":    {"required": ["ACTION_ASK", "OBJ_HVAC"], "optional": []},
+    # timers & alarms
+    "set_timer":     {"required": ["ACTION_SET", "OBJ_TIMER"], "optional": []},
+    "cancel_timer":  {"required": ["ACTION_CANCEL", "OBJ_TIMER"], "optional": []},
+    "set_alarm":     {"required": ["ACTION_SET", "OBJ_ALARM"], "optional": []},
+    "cancel_alarm":  {"required": ["ACTION_CANCEL", "OBJ_ALARM"], "optional": []},
+    # weather
+    "weather_query": {"required": ["OBJ_WEATHER"], "optional": []},
+    # reminders
+    "add_reminder":  {"required": ["OBJ_REMINDER"], "optional": []},
+    # communication
+    "call_contact":  {"required": ["OBJ_PHONE"], "optional": []},
+    "send_message":  {"required": ["ACTION_SEND", "OBJ_MESSAGE"], "optional": []},
+    "add_note":      {"required": ["ACTION_SEND", "OBJ_NOTE"], "optional": []},
+    # shopping
+    "add_shopping":  {"required": ["OBJ_SHOPPING"], "optional": []},
+    # information
+    "time_query":    {"required": ["ACTION_ASK", "OBJ_TIME"], "optional": []},
+    "date_query":    {"required": ["ACTION_ASK", "OBJ_DATE"], "optional": []},
+    "search_query":  {"required": ["OBJ_SEARCH"], "optional": []},
+    # navigation
+    "navigate_to":   {"required": ["ACTION_GO"], "optional": []},
+    # system
+    "get_help":      {"required": ["OBJ_HELP"], "optional": []},
+    "stop_all":      {"required": ["OBJ_HALT"], "optional": []},
 }
 
 # ── domain grouping ────────────────────────────────────────────────────────
-# Semantically related intents grouped into domains. The domain engine gives
-# each domain its own isolated sub-engine (separate Trie + entity tagger).
 
 DOMAINS = {
-    "media":         ["play_music", "pause_music", "next_track", "set_volume"],
-    "timers_alarms": ["set_timer", "set_alarm", "cancel_timer", "add_reminder"],
-    "weather":       ["weather_query"],
+    "media":         ["play_music", "pause_music", "next_track",
+                      "volume_up", "volume_down"],
     "lights":        ["lights_on", "lights_off"],
-    "climate":       ["thermostat_set"],
+    "climate":       ["heating_up", "heating_down", "check_hvac"],
+    "timers":        ["set_timer", "cancel_timer", "set_alarm", "cancel_alarm"],
+    "weather":       ["weather_query"],
+    "reminders":     ["add_reminder"],
     "communication": ["call_contact", "send_message", "add_note"],
     "shopping":      ["add_shopping"],
     "information":   ["time_query", "date_query", "search_query"],
     "navigation":    ["navigate_to"],
-    "system":        ["help", "stop"],
+    "system":        ["get_help", "stop_all"],
 }
 
 # ── labelled test utterances ───────────────────────────────────────────────
 
 TEST_CASES = [
-    # play_music
-    ("play some jazz please",               "play_music"),
-    ("put on some background music",        "play_music"),
-    ("i want to hear something calm",       "play_music"),
-    ("can you play the beatles",            "play_music"),
-    ("chuck on a playlist",                 "play_music"),
-    ("start playing something upbeat",      "play_music"),
-    ("stick on some tunes",                 "play_music"),
-    ("get some lo-fi going",                "play_music"),
-    ("listen to pink floyd",                "play_music"),
-    ("play that song i like",               "play_music"),
+    # play_music — ACTION_PLAY + OBJ_MUSIC
+    ("play some music",                       "play_music"),
+    ("put on a song",                         "play_music"),
+    ("play my favourite playlist",            "play_music"),
+    ("queue up the next album",               "play_music"),
+    ("put on a podcast",                      "play_music"),
+    ("play that track again please",          "play_music"),
+    ("can you play some music",               "play_music"),
 
-    # pause_music
-    ("pause the music",                     "pause_music"),
-    ("stop the track",                      "pause_music"),
-    ("pause that song for a moment",        "pause_music"),
-    ("can you stop the music please",       "pause_music"),
-    ("halt the music",                      "pause_music"),
+    # pause_music — ACTION_STOP + OBJ_MUSIC
+    ("pause the music",                       "pause_music"),
+    ("stop the song",                         "pause_music"),
+    ("halt the playlist",                     "pause_music"),
+    ("pause this track for a sec",            "pause_music"),
+    ("can you stop the music please",         "pause_music"),
 
-    # next_track
-    ("next track please",                   "next_track"),
-    ("skip this song",                      "next_track"),
-    ("skip to the next one",                "next_track"),
-    ("next please",                         "next_track"),
-    ("skip forward a track",                "next_track"),
+    # next_track — ACTION_SKIP (+ OBJ_MUSIC)
+    ("next track",                            "next_track"),
+    ("skip this song",                        "next_track"),
+    ("skip",                                  "next_track"),
+    ("next please",                           "next_track"),
+    ("skip to the next track",                "next_track"),
 
-    # set_volume
-    ("volume up please",                    "set_volume"),
-    ("make it louder",                      "set_volume"),
-    ("turn it down a bit",                  "set_volume"),
-    ("could you turn the volume down",      "set_volume"),
-    ("crank up the volume",                 "set_volume"),
-    ("volume quieter please",               "set_volume"),
+    # volume_up — ACTION_RAISE + OBJ_AUDIO
+    ("turn up the volume",                    "volume_up"),
+    ("crank up the volume please",            "volume_up"),
+    ("raise the volume a bit",                "volume_up"),
+    ("increase the volume",                   "volume_up"),
+    ("turn up the music",                     "volume_up"),
 
-    # set_timer
-    ("set a timer please",                  "set_timer"),
-    ("can you set a timer for five minutes", "set_timer"),
-    ("start a countdown",                   "set_timer"),
-    ("make a ten minute timer",             "set_timer"),
-    ("create a timer for half an hour",     "set_timer"),
+    # volume_down — ACTION_LOWER + OBJ_AUDIO
+    ("turn down the volume",                  "volume_down"),
+    ("lower the volume",                      "volume_down"),
+    ("decrease the volume a little",          "volume_down"),
+    ("turn down the music please",            "volume_down"),
 
-    # set_alarm
-    ("wake me up at seven",                 "set_alarm"),
-    ("set an alarm for six thirty",         "set_alarm"),
-    ("i need an alarm",                     "set_alarm"),
-    ("wake me tomorrow morning",            "set_alarm"),
-    ("get me up at six",                    "set_alarm"),
+    # lights_on — ACTION_ON + OBJ_LIGHT
+    ("turn on the lights",                    "lights_on"),
+    ("switch on the lamp",                    "lights_on"),
+    ("turn on the light in here",             "lights_on"),
+    ("enable the lighting",                   "lights_on"),
+    ("can you turn on the lights",            "lights_on"),
 
-    # cancel_timer
-    ("cancel the timer",                    "cancel_timer"),
-    ("stop the timer",                      "cancel_timer"),
-    ("delete the countdown",                "cancel_timer"),
-    ("get rid of the timer",                "cancel_timer"),
-    ("turn off the timer",                  "cancel_timer"),
+    # lights_off — ACTION_OFF + OBJ_LIGHT
+    ("turn off the lights",                   "lights_off"),
+    ("switch off the lamp",                   "lights_off"),
+    ("turn off the light please",             "lights_off"),
+    ("disable the lighting",                  "lights_off"),
 
-    # weather_query
-    ("what's the weather like today",       "weather_query"),
-    ("do i need an umbrella",               "weather_query"),
-    ("is it going to rain",                 "weather_query"),
-    ("should i bring a coat",               "weather_query"),
-    ("how cold is it outside",              "weather_query"),
-    ("what's the forecast",                 "weather_query"),
-    ("is it sunny today",                   "weather_query"),
-    ("what's the temperature",              "weather_query"),
+    # heating_up — ACTION_RAISE + OBJ_HVAC
+    ("turn up the heating",                   "heating_up"),
+    ("crank up the heater",                   "heating_up"),
+    ("raise the thermostat",                  "heating_up"),
+    ("increase the heating a bit",            "heating_up"),
 
-    # lights_on
-    ("turn the lights on please",           "lights_on"),
-    ("lights on",                           "lights_on"),
-    ("switch on the lights",                "lights_on"),
-    ("can you flick on the lights",         "lights_on"),
-    ("brighten the lights up",              "lights_on"),
+    # heating_down — ACTION_LOWER + OBJ_HVAC
+    ("turn down the heating",                 "heating_down"),
+    ("lower the thermostat",                  "heating_down"),
+    ("decrease the heating",                  "heating_down"),
+    ("turn down the radiator please",         "heating_down"),
 
-    # lights_off
-    ("turn the lights off",                 "lights_off"),
-    ("lights off please",                   "lights_off"),
-    ("switch off the lights",               "lights_off"),
-    ("dim the lights",                      "lights_off"),
-    ("go dark",                             "lights_off"),
-    ("kill the lights",                     "lights_off"),
+    # check_hvac — ACTION_ASK + OBJ_HVAC
+    ("what's the thermostat at",              "check_hvac"),
+    ("check the heating",                     "check_hvac"),
+    ("tell me the thermostat setting",        "check_hvac"),
+    ("how's the heating doing",               "check_hvac"),
 
-    # thermostat_set
-    ("set the thermostat",                  "thermostat_set"),
-    ("adjust the heating",                  "thermostat_set"),
-    ("it's freezing turn the heating up",   "thermostat_set"),
-    ("can you cool it down",                "thermostat_set"),
-    ("make it warmer in here",              "thermostat_set"),
-    ("change the temperature please",       "thermostat_set"),
+    # set_timer — ACTION_SET + OBJ_TIMER
+    ("set a timer",                           "set_timer"),
+    ("create a timer for ten minutes",        "set_timer"),
+    ("start a countdown",                     "set_timer"),
+    ("make a timer for five minutes",         "set_timer"),
 
-    # call_contact
-    ("call alice please",                   "call_contact"),
-    ("ring dad",                            "call_contact"),
-    ("phone the office",                    "call_contact"),
-    ("dial charlie",                        "call_contact"),
-    ("can you get sarah on the line",       "call_contact"),
+    # cancel_timer — ACTION_CANCEL + OBJ_TIMER
+    ("cancel the timer",                      "cancel_timer"),
+    ("delete the timer",                      "cancel_timer"),
+    ("clear the countdown",                   "cancel_timer"),
+    ("remove the timer please",               "cancel_timer"),
 
-    # send_message
-    ("send a message to alice",             "send_message"),
-    ("text john please",                    "send_message"),
-    ("drop bob a message",                  "send_message"),
-    ("ping sarah",                          "send_message"),
-    ("shoot charlie a text",                "send_message"),
+    # set_alarm — ACTION_SET + OBJ_ALARM
+    ("set an alarm",                          "set_alarm"),
+    ("create an alarm for seven",             "set_alarm"),
+    ("make an alarm for the morning",         "set_alarm"),
+    ("schedule an alarm",                     "set_alarm"),
 
-    # add_note
-    ("take a note",                         "add_note"),
-    ("write this down",                     "add_note"),
-    ("make a note of that",                 "add_note"),
-    ("jot this down please",                "add_note"),
-    ("note that the meeting moved",         "add_note"),
+    # cancel_alarm — ACTION_CANCEL + OBJ_ALARM
+    ("cancel the alarm",                      "cancel_alarm"),
+    ("delete the alarm",                      "cancel_alarm"),
+    ("remove the alarm",                      "cancel_alarm"),
+    ("clear the alarm please",                "cancel_alarm"),
 
-    # add_shopping
-    ("add milk to the shopping list",       "add_shopping"),
-    ("put bread on the shopping list",      "add_shopping"),
-    ("we need to buy coffee",               "add_shopping"),
-    ("running low on eggs",                 "add_shopping"),
-    ("pick up some cheese",                 "add_shopping"),
-    ("out of washing up liquid",            "add_shopping"),
+    # weather_query — OBJ_WEATHER
+    ("what's the weather",                    "weather_query"),
+    ("is it going to rain",                   "weather_query"),
+    ("do i need an umbrella",                 "weather_query"),
+    ("what's the forecast",                   "weather_query"),
+    ("is there snow coming",                  "weather_query"),
+    ("what's the temperature outside",        "weather_query"),
 
-    # time_query
-    ("what time is it",                     "time_query"),
-    ("what's the time",                     "time_query"),
-    ("current time please",                 "time_query"),
-    ("time check",                          "time_query"),
-    ("how late is it",                      "time_query"),
-    ("what hour is it",                     "time_query"),
+    # add_reminder — OBJ_REMINDER
+    ("set a reminder",                        "add_reminder"),
+    ("remind me to buy milk",                 "add_reminder"),
+    ("create a reminder for the meeting",     "add_reminder"),
+    ("add a reminder",                        "add_reminder"),
 
-    # date_query
-    ("what day is it today",                "date_query"),
-    ("what's today's date",                 "date_query"),
-    ("what month are we in",                "date_query"),
-    ("what day of the week is it",          "date_query"),
-    ("is today a monday",                   "date_query"),
+    # call_contact — OBJ_PHONE
+    ("call mum",                              "call_contact"),
+    ("phone the office",                      "call_contact"),
+    ("dial charlie",                          "call_contact"),
+    ("ring my brother",                       "call_contact"),
 
-    # search_query
-    ("search for the nearest pharmacy",     "search_query"),
-    ("look up sourdough recipe",            "search_query"),
-    ("google how to fix a leak",            "search_query"),
-    ("find a good pizza place",             "search_query"),
-    ("what is photosynthesis",              "search_query"),
-    ("what are the symptoms of a cold",     "search_query"),
+    # send_message — ACTION_SEND + OBJ_MESSAGE
+    ("send a message to bob",                 "send_message"),
+    ("write a text to alice",                 "send_message"),
+    ("draft an email",                        "send_message"),
+    ("send a text please",                    "send_message"),
 
-    # navigate_to
-    ("navigate to the airport",             "navigate_to"),
-    ("get directions to the hospital",      "navigate_to"),
-    ("take me to the station",              "navigate_to"),
-    ("how do i get to the city centre",     "navigate_to"),
-    ("find a route to the supermarket",     "navigate_to"),
-    ("get me to work please",               "navigate_to"),
+    # add_note — ACTION_SEND + OBJ_NOTE
+    ("write a note",                          "add_note"),
+    ("jot down a note",                       "add_note"),
+    ("leave a note for sam",                  "add_note"),
+    ("draft a memo",                          "add_note"),
 
-    # help
-    ("help",                                "help"),
-    ("what can you do",                     "help"),
-    ("list your skills please",             "help"),
-    ("show me your capabilities",           "help"),
-    ("what commands do you know",           "help"),
+    # add_shopping — OBJ_SHOPPING
+    ("add milk to the shopping list",         "add_shopping"),
+    ("i need to buy groceries",               "add_shopping"),
+    ("add eggs to the shopping",              "add_shopping"),
 
-    # stop
-    ("stop",                                "stop"),
-    ("cancel that",                         "stop"),
-    ("never mind",                          "stop"),
-    ("forget it",                           "stop"),
-    ("abort",                               "stop"),
-    ("scrap that",                          "stop"),
-    ("leave it",                            "stop"),
-    ("don't bother",                        "stop"),
+    # time_query — ACTION_ASK + OBJ_TIME
+    ("what is the time",                      "time_query"),
+    ("tell me the time",                      "time_query"),
+    ("check the time for me",                 "time_query"),
+    ("what's the time",                       "time_query"),
 
-    # ── harder cases: keyword present but embedded in longer phrasing ──────
-    ("can you turn the volume up a bit please",      "set_volume"),
-    ("it is way too loud in here turn it down",      "set_volume"),
-    ("do me a favour and ring my dad",               "call_contact"),
-    ("go ahead and navigate me to the supermarket",  "navigate_to"),
-    ("i think we need to buy some milk actually",    "add_shopping"),
-    ("can you just search for the nearest chemist",  "search_query"),
-    ("set a ten minute timer would you",             "set_timer"),
-    ("could you wake me up at half six tomorrow",    "set_alarm"),
-    ("what's the weather going to be like tomorrow", "weather_query"),
-    ("can someone tell me what time it is",          "time_query"),
-    ("go on then cancel the timer",                  "cancel_timer"),
-    ("lights please turn them on",                   "lights_on"),
-    ("flip the lights off would you",                "lights_off"),
-    ("can you look up what the capital of france is","search_query"),
-    ("dial my brother's number",                     "call_contact"),
-    ("drop sarah a quick text saying i'm on my way", "send_message"),
-    ("jot this down the meeting is at three",        "add_note"),
-    ("add bananas and milk to the shopping please",  "add_shopping"),
-    ("get directions to the nearest hospital",       "navigate_to"),
-    ("give me a hand what day is it today",          "date_query"),
+    # date_query — ACTION_ASK + OBJ_DATE
+    ("what's the date",                       "date_query"),
+    ("tell me the date",                      "date_query"),
+    ("what is today's date",                  "date_query"),
+    ("what's today",                          "date_query"),
 
-    # ── ambiguous phrasing (correct intent requires keyword disambiguation) ─
-    ("the temperature please",                       "weather_query"),
-    ("it's really cold outside",                     "weather_query"),
-    ("turn the heating up a few degrees",            "thermostat_set"),
-    ("skip to the next track please",                "next_track"),
-    ("i need to be reminded to call the dentist",    "add_reminder"),
-    ("put a reminder on for my doctor's appointment","add_reminder"),
+    # search_query — OBJ_SEARCH
+    ("search for nearby restaurants",         "search_query"),
+    ("look up the train times",               "search_query"),
+    ("google italian recipes",                "search_query"),
+    ("search for a plumber",                  "search_query"),
 
-    # ── short utterances (1–3 words) ──────────────────────────────────────
-    ("play",                    "play_music"),
-    ("pause the music",             "pause_music"),
-    ("next",                    "next_track"),
-    ("louder",                  "set_volume"),
-    ("quieter",                 "set_volume"),
-    ("timer",                   "set_timer"),
-    ("cancel",                  "stop"),
-    ("navigate",                "navigate_to"),
-    ("search",                  "search_query"),
-    ("lights on",               "lights_on"),
-    ("lights off",              "lights_off"),
-    ("time please",             "time_query"),
-    ("what day",                "date_query"),
-    ("call mum",                "call_contact"),
-    ("text alice",              "send_message"),
-    ("write this",              "add_note"),
-    ("buy milk",                "add_shopping"),
-    ("wake me",                 "set_alarm"),
-    ("the weather",             "weather_query"),
+    # navigate_to — ACTION_GO
+    ("navigate to the airport",               "navigate_to"),
+    ("take me to the station",                "navigate_to"),
+    ("drive to the office",                   "navigate_to"),
+    ("directions to the hospital",            "navigate_to"),
+    ("get me to work",                        "navigate_to"),
 
-    # ── medium utterances (4–8 words) ────────────────────────────────────
-    ("skip this i don't like it",                   "next_track"),
-    ("how warm is it today",                        "weather_query"),
-    ("remind me about the meeting",                 "add_reminder"),
-    ("send bob a quick message",                    "send_message"),
-    ("turn up the volume a bit",                    "set_volume"),
-    ("what time does the sun set",                  "time_query"),
-    ("look up the bus timetable",                   "search_query"),
-    ("put a timer on for lunch",                    "set_timer"),
-    ("phone my sister in law",                      "call_contact"),
-    ("write down eggs butter flour",                "add_note"),
-    ("get directions to the station",               "navigate_to"),
-    ("turn the heating down a bit",                 "thermostat_set"),
-    ("add bread to shopping list",                  "add_shopping"),
-    ("set an alarm for six am",                     "set_alarm"),
-    ("switch the bathroom light on",                "lights_on"),
-    ("can you stop the current song",               "pause_music"),
+    # get_help — OBJ_HELP
+    ("help",                                  "get_help"),
+    ("what commands do you have",             "get_help"),
+    ("i need help",                           "get_help"),
 
-    # ── long utterances (9–14 words) ─────────────────────────────────────
-    ("i was wondering if you could look up how to make pasta carbonara",   "search_query"),
-    ("do you think you could turn the music down just a little bit please","set_volume"),
-    ("i need you to set a reminder so i don't forget to take my tablets",  "add_reminder"),
-    ("could you get directions to the nearest petrol station from here",   "navigate_to"),
-    ("i'd really appreciate it if you could turn the lights off in here",  "lights_off"),
-    ("before i go to bed can you set an alarm for half past six tomorrow", "set_alarm"),
-    ("actually you know what just cancel that ignore everything i said",   "stop"),
-    ("is it going to be warm enough to go outside without a coat today",   "weather_query"),
-    ("can you put oat milk and a dozen eggs on the shopping list for me",  "add_shopping"),
-    ("i need to call the doctor's surgery can you dial them for me please","call_contact"),
-    ("write this down i owe sarah twenty quid for the cinema last night",  "add_note"),
-    ("set a five minute countdown so i know when to take the pasta off",   "set_timer"),
-    ("let me know what time it is i've completely lost track of the day",  "time_query"),
-    ("is there any chance you could bump the thermostat up a few degrees", "thermostat_set"),
-    ("can you skip this track i've heard it about a hundred times already","next_track"),
+    # stop_all — OBJ_HALT
+    ("stop",                                  "stop_all"),
+    ("cancel",                                "stop_all"),
+    ("abort",                                 "stop_all"),
+    ("never mind",                            "stop_all"),
 
-    # ── very long utterances (15+ words) ─────────────────────────────────
-    ("i know this is a bit of a long one but could you please navigate me to the shopping centre on the high street", "navigate_to"),
-    ("i'm running a bit late and i was wondering if you could send a message to alice letting her know i'll be there in about twenty minutes", "send_message"),
-    ("look i really don't want to forget this so could you please write it down somewhere the pin for my new card is one two three four", "add_note"),
-    ("i've been trying to remember all morning what time my dentist appointment is and i just cannot work it out can you look it up for me", "search_query"),
-    ("the music is absolutely lovely but honestly it is just a tiny little bit too loud for me right now so could you turn it down please", "set_volume"),
-    ("it's been a really long week and i just want to relax so could you put on something calm and peaceful to listen to in the background", "play_music"),
-    ("i need to be up early tomorrow for a really important meeting so could you set an alarm for six o'clock in the morning without fail please", "set_alarm"),
-    ("before we head out i want to make sure the lights are all switched off so could you please go ahead and turn them all off right now", "lights_off"),
+    # ── cross-domain action collision ─────────────────────────────────────
+    # The ACTION keyword is shared across domains; the OBJECT decides the
+    # domain. A correct engine follows the object, not the action.
+    ("turn up the heating in here",           "heating_up"),
+    ("turn up the volume on the stereo",      "volume_up"),
+    ("crank up the radiator",                 "heating_up"),
+    ("crank up the music",                    "volume_up"),
+    ("switch on the kitchen lamp",            "lights_on"),
+    ("pause the podcast",                     "pause_music"),
+    ("set a timer for the pasta",             "set_timer"),
+    ("set an alarm for the gym",              "set_alarm"),
 
-    # ── multi-intent queries: two intents' keywords both present ──────────
-    # The labelled intent is the one a parser should prefer (higher coverage /
-    # more required slots matched).  These stress-test disambiguation logic.
-    ("stop the music and cancel my alarm",
-     "pause_music"),       # StopKeyword+MusicKeyword outranks cancel alone
-    ("turn off the lights and set a timer for ten minutes",
-     "set_timer"),         # primary intent is setting a timer
-    ("skip this song and turn it up",
-     "next_track"),        # next_track keyword more specific than volume alone
-    ("call alice and remind her about the meeting",
-     "call_contact"),      # CallKeyword direct; remind surfaces as optional
-    ("what time is it and what's the weather like",
-     "time_query"),        # time_query slots dominate in this ordering
-    ("search for pizza places and navigate to the best one",
-     "navigate_to"),       # navigate has stronger required-keyword coverage
-    ("set a timer and remind me to check it",
-     "add_reminder"),      # remind slot wins; set+timer covered but remind more specific
-    ("send a message to bob and add milk to the shopping list",
-     "send_message"),      # MessageKeyword direct match wins
-    ("cancel the alarm and never mind the timer",
-     "stop"),              # StopCancelKeyword matches "never mind"; cancel alone fires stop
-    ("pause the music and turn down the volume",
-     "set_volume"),        # VolumeKeyword+DirectionKeyword outranks pause_music coverage
-
-    # ── entity-overlap cases ──────────────────────────────────────────────
-    # Each utterance contains a word registered under two or more entity
-    # types spanning two or more domains. The correct intent is decided by
-    # the *other* keywords present. These stress whether per-domain trie
-    # isolation changes the matched intent versus a shared trie.
-
-    # "turn up" / "turn down" / "crank up" — VolumeKeyword (media)
-    #                                        ∩ Heat/CoolKeyword (climate)
-    ("turn up the music a bit",             "set_volume"),
-    ("turn up the volume now",              "set_volume"),
-    ("crank up the tunes",                  "set_volume"),
-    ("turn down the music",                 "set_volume"),
-    ("turn down the volume a little",       "set_volume"),
-    ("ease off the volume",                 "set_volume"),
-    ("turn up the heating",                 "thermostat_set"),
-    ("crank up the heating please",         "thermostat_set"),
-    ("turn down the heating",               "thermostat_set"),
-    ("turn down the thermostat",            "thermostat_set"),
-    ("turn up the heat in here",            "thermostat_set"),
-
-    # "temperature" / "hot" / "cold" / "warm" — WeatherKeyword (weather)
-    #                          ∩ Thermostat/Heat/CoolKeyword (climate)
-    ("what's the temperature outside",      "weather_query"),
-    ("is it hot out today",                 "weather_query"),
-    ("is it cold out",                      "weather_query"),
-    ("is it warm out there",                "weather_query"),
-    ("set the thermostat temperature",      "thermostat_set"),
-    ("check the thermostat",                "thermostat_set"),
-    ("lower the thermostat",                "thermostat_set"),
-    ("drop it a couple of degrees",         "thermostat_set"),
-    ("bump it up a few degrees",            "thermostat_set"),
-
-    # "stop" / "pause" / "halt" / "cancel" — StopKeyword (media)
-    #                  ∩ Cancel/StopCancelKeyword (timers / system)
-    ("stop the music",                      "pause_music"),
-    ("pause the track",                     "pause_music"),
-    ("halt the song",                       "pause_music"),
-    ("cancel the timer right now",          "cancel_timer"),
-    ("stop the countdown",                  "cancel_timer"),
-    ("delete the timer",                    "cancel_timer"),
-    ("abort the whole thing",               "stop"),
-    ("never mind cancel it",                "stop"),
-
-    # "kill" — CancelKeyword (timers) ∩ OffKeyword (lights)
-    ("kill the timer",                      "cancel_timer"),
-    ("kill the bedroom lights",             "lights_off"),
-
-    # "start" / "make" — SetKeyword (timers)
-    ("start a timer for me",                "set_timer"),
-    ("make a quick timer",                  "set_timer"),
+    # ── domain-context cases ──────────────────────────────────────────────
+    # The utterance's dominant intent matches cleanly on coverage, but a
+    # keyword for a single-slot intent in another domain is also present
+    # as a distractor. The dominant intent should still win.
+    ("play the song on the radio",            "play_music"),
+    ("put on a podcast about the weather",    "play_music"),
+    ("turn off the lights then call mum",     "lights_off"),
+    ("write a note about the shopping",       "add_note"),
+    ("set a timer for the laundry",           "set_timer"),
 ]
 
 # ── no-match utterances ────────────────────────────────────────────────────
-# Includes both easy (no keyword overlap) and hard (surface keyword present
-# but not a command) cases to stress-test false-positive rate.
+# Plausible but not commands. Many contain a keyword used outside a command
+# context to stress the false-positive rate.
 
 NO_MATCH_UTTERANCES = [
-    # ── easy: conversational / off-topic — no keyword overlap ────────────────
+    # conversational / off-topic
     "um yeah so anyway",
     "right okay then",
     "hmm not sure about that",
-    "oh interesting",
-    "fair enough",
+    "oh that's interesting",
+    "fair enough i suppose",
     "the dog ate my homework",
-    "i've been thinking about getting a new sofa",
     "did you see the match last night",
-    "my knee's been giving me trouble",
-    "i went to the dentist yesterday",
-    "what a lovely afternoon it is",
+    "my knee has been giving me trouble",
+    "what a lovely afternoon",
     "i really fancy a cup of tea",
-    "the cat's been acting strange all week",
-    "that film last night was brilliant",
-    "i can't believe how fast the year's gone",
-    "my back's been killing me since tuesday",
+    "the cat has been acting strange",
+    "that film was brilliant",
+    "i can't believe how fast the year went",
 
-    # ── single keyword present but not a command ──────────────────────────────
-    "my friend alice rang me earlier",             # 'ring' ∈ CallKeyword
-    "the music at that restaurant was terrible",   # 'music' ∈ MusicKeyword
-    "i watched a documentary about the weather",   # 'weather' ∈ WeatherKeyword
-    "the lights were beautiful at the concert",    # 'lights' ∈ LightKeyword (no on/off)
-    "the alarm woke the whole street",             # 'alarm' ∈ AlarmKeyword
-    "my shopping bag broke",                       # 'shopping' ∈ ShoppingKeyword
-    "the timer on the oven is broken",             # 'timer' ∈ TimerKeyword
-    "i always stop for coffee in the morning",     # 'stop' ∈ StopKeyword
-    "she left me a note on the table",             # 'note' ∈ NoteKeyword
-    "the day was long",                            # 'day' ∈ DateKeyword
-    "he could navigate by the stars",              # 'navigate' ∈ NavigateKeyword
-    "she sent a text to her mum",                  # 'text'+'send' — past tense report
-    "the play was set in the victorian era",       # 'set' ∈ SetKeyword
-    "we need more people like her",                # 'need' ∈ ShoppingKeyword
-    "the volume of complaints has gone up",        # 'volume' ∈ VolumeKeyword — noun
-    "the track record speaks for itself",          # 'track' ∈ MusicKeyword — idiom
-    "i find that hard to believe",                 # 'find' ∈ SearchKeyword — not a search
-    "next time i'll remember",                     # 'next' ∈ NextKeyword — temporal not skip
-    "the forecast was wrong again",                # 'forecast' ∈ WeatherKeyword — report
-    "they called an emergency meeting",            # 'called' ∈ CallKeyword — past tense
+    # single object keyword, no action — must not fire a two-slot intent
+    "the music at the restaurant was lovely",
+    "the lights looked beautiful at the concert",
+    "the heating bill was enormous this month",
+    "the alarm woke the whole street",
+    "the timer on the oven is broken",
+    "she left her phone on the table",
+    "the weather has been miserable lately",
+    "my shopping bag split open",
+    "the thermostat is on the hallway wall",
+    "the radiator needs bleeding again",
+    "i love a good podcast on a long drive",
 
-    # ── multiple keywords present, still not a command ────────────────────────
-    "the weather alarm went off at six",           # 'weather'+'alarm' — description
-    "i need to buy some time",                     # 'buy'+'time' — idiom
-    "call it a day",                               # 'call'+'day' — idiom
-    "stop and note the temperature outside",       # many keywords — observation
-    "the lights went out and the alarm sounded",   # passive, not a command
-    "i sent a message about the shopping list",    # 'message'+'shopping' — past tense
-    "ring the timer when the alarm goes off",      # 'ring'+'timer'+'alarm' — description
-    "the forecast says it will be cold tomorrow",  # 'weather' paraphrase, not a query
-    "turn it up was the band's best album",        # 'turn up' ∈ VolumeKeyword — not a command
-    "she set the timer and then went to bed",      # past tense narrative
-    "the note said to call him back by noon",      # 'note'+'call' — reporting, not commands
-    "they found the route on an old map",          # 'found'+'route' — narrative
-    "he wrote down the directions to the shop",    # 'write'+'directions' — past tense
-    "we get the alarm serviced every year",        # 'alarm' in factual context
-    "the shopping channel was on all night",       # 'shopping' — noun, not list command
+    # action keyword, no object — must not fire a two-slot intent
+    "could you turn it up a bit",
+    "go ahead and switch it on",
+    "i need you to turn that down",
+    "just put it on for me",
+    "can you cancel it",
 
-    # ── rhetorical / hypothetical — sound like commands but aren't ───────────
-    "what would you do if the lights went out",    # conditional question
-    "wouldn't it be nice to skip all the boring bits", # hypothetical, not a skip command
-    "who even sets an alarm on a saturday",        # rhetorical
-    "can you believe they cancelled the gig",      # 'cancel' — rhetorical question
-    "imagine if you could just turn down the noise", # hypothetical
-    "do you think it will rain at the weekend",    # opinion question, not weather command
-    "i wonder what the time is in new york",       # musing, not a time query command
+    # overlapping keyword used non-literally
+    "they cancel each other out",
+    "let's call it a day",
+    "he was dead set against the idea",
+    "give the new hire a warm welcome",
+    "kill the engine before you park",
+    "stop right there",
+    "i had to turn down the job offer",
+    "the music just would not stop",
 
-    # ── third-person / reported speech — describing others' actions ───────────
-    "she asked him to call her back later",        # 'call' — reported request
-    "they said the music was too loud at the party", # 'music' — reported complaint
-    "my mum always sets three alarms just in case", # 'alarms' — describing habit
-    "the kids wanted to play something different",  # 'play' — not a media command
+    # rhetorical / reported speech
+    "who even sets an alarm on a sunday",
+    "she asked him to call her back",
+    "they said the music was too loud",
+    "what would you do if the lights went out",
+    "imagine if you could just skip the boring bits",
 
-    # ── entity-overlap no-match: overlapping keyword present, not a command ──
-    "did anything turn up at the office",          # 'turn up' ∈ Volume/Heat
-    "i had to turn down the invitation",           # 'turn down' ∈ Volume/Cool
-    "the music just would not stop",               # 'stop'+'music' — narrative
-    "it was stone cold by then",                   # 'cold' ∈ Weather/Cool — idiom
-    "the hot topic was politics all evening",      # 'hot' ∈ Weather/Heat
-    "they cancel each other out",                  # 'cancel' — idiom
-    "he was dead set against the idea",            # 'set' ∈ SetKeyword — idiom
-    "the heating engineer came round today",       # 'heating' ∈ Thermostat
-    "kill the engine before you park",             # 'kill' ∈ Cancel/Off
-    "her degrees were framed on the wall",         # 'degrees' ∈ Thermostat
-    "i need to cool off after that argument",      # 'cool' ∈ Thermostat/Cool
-    "the temperature of the debate rose",          # 'temperature' ∈ Weather/Thermostat
-    "give the new hire a warm welcome",            # 'warm' ∈ Weather/Heat
-
-    # ── nonsense ──────────────────────────────────────────────────────────────
+    # nonsense
     "blarg wump fizz",
-    "one fish two fish red fish blue fish",
-    "supercalifragilistic",
+    "one fish two fish red fish",
     "lorem ipsum dolor sit amet",
     "the mitochondria is the powerhouse of the cell",
 ]

--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -502,6 +502,57 @@ TEST_CASES = [
      "stop"),              # StopCancelKeyword matches "never mind"; cancel alone fires stop
     ("pause the music and turn down the volume",
      "set_volume"),        # VolumeKeyword+DirectionKeyword outranks pause_music coverage
+
+    # ── entity-overlap cases ──────────────────────────────────────────────
+    # Each utterance contains a word registered under two or more entity
+    # types spanning two or more domains. The correct intent is decided by
+    # the *other* keywords present. These stress whether per-domain trie
+    # isolation changes the matched intent versus a shared trie.
+
+    # "turn up" / "turn down" / "crank up" — VolumeKeyword (media)
+    #                                        ∩ Heat/CoolKeyword (climate)
+    ("turn up the music a bit",             "set_volume"),
+    ("turn up the volume now",              "set_volume"),
+    ("crank up the tunes",                  "set_volume"),
+    ("turn down the music",                 "set_volume"),
+    ("turn down the volume a little",       "set_volume"),
+    ("ease off the volume",                 "set_volume"),
+    ("turn up the heating",                 "thermostat_set"),
+    ("crank up the heating please",         "thermostat_set"),
+    ("turn down the heating",               "thermostat_set"),
+    ("turn down the thermostat",            "thermostat_set"),
+    ("turn up the heat in here",            "thermostat_set"),
+
+    # "temperature" / "hot" / "cold" / "warm" — WeatherKeyword (weather)
+    #                          ∩ Thermostat/Heat/CoolKeyword (climate)
+    ("what's the temperature outside",      "weather_query"),
+    ("is it hot out today",                 "weather_query"),
+    ("is it cold out",                      "weather_query"),
+    ("is it warm out there",                "weather_query"),
+    ("set the thermostat temperature",      "thermostat_set"),
+    ("check the thermostat",                "thermostat_set"),
+    ("lower the thermostat",                "thermostat_set"),
+    ("drop it a couple of degrees",         "thermostat_set"),
+    ("bump it up a few degrees",            "thermostat_set"),
+
+    # "stop" / "pause" / "halt" / "cancel" — StopKeyword (media)
+    #                  ∩ Cancel/StopCancelKeyword (timers / system)
+    ("stop the music",                      "pause_music"),
+    ("pause the track",                     "pause_music"),
+    ("halt the song",                       "pause_music"),
+    ("cancel the timer right now",          "cancel_timer"),
+    ("stop the countdown",                  "cancel_timer"),
+    ("delete the timer",                    "cancel_timer"),
+    ("abort the whole thing",               "stop"),
+    ("never mind cancel it",                "stop"),
+
+    # "kill" — CancelKeyword (timers) ∩ OffKeyword (lights)
+    ("kill the timer",                      "cancel_timer"),
+    ("kill the bedroom lights",             "lights_off"),
+
+    # "start" / "make" — SetKeyword (timers)
+    ("start a timer for me",                "set_timer"),
+    ("make a quick timer",                  "set_timer"),
 ]
 
 # ── no-match utterances ────────────────────────────────────────────────────
@@ -580,6 +631,21 @@ NO_MATCH_UTTERANCES = [
     "they said the music was too loud at the party", # 'music' — reported complaint
     "my mum always sets three alarms just in case", # 'alarms' — describing habit
     "the kids wanted to play something different",  # 'play' — not a media command
+
+    # ── entity-overlap no-match: overlapping keyword present, not a command ──
+    "did anything turn up at the office",          # 'turn up' ∈ Volume/Heat
+    "i had to turn down the invitation",           # 'turn down' ∈ Volume/Cool
+    "the music just would not stop",               # 'stop'+'music' — narrative
+    "it was stone cold by then",                   # 'cold' ∈ Weather/Cool — idiom
+    "the hot topic was politics all evening",      # 'hot' ∈ Weather/Heat
+    "they cancel each other out",                  # 'cancel' — idiom
+    "he was dead set against the idea",            # 'set' ∈ SetKeyword — idiom
+    "the heating engineer came round today",       # 'heating' ∈ Thermostat
+    "kill the engine before you park",             # 'kill' ∈ Cancel/Off
+    "her degrees were framed on the wall",         # 'degrees' ∈ Thermostat
+    "i need to cool off after that argument",      # 'cool' ∈ Thermostat/Cool
+    "the temperature of the debate rose",          # 'temperature' ∈ Weather/Thermostat
+    "give the new hire a warm welcome",            # 'warm' ∈ Weather/Heat
 
     # ── nonsense ──────────────────────────────────────────────────────────────
     "blarg wump fizz",

--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -1,9 +1,13 @@
 """
-Keyword-intent benchmark dataset for the Adapt engine.
+Engine-comparison reference corpus for the Adapt engine.
 
-Used to compare three engine topologies on identical vocabulary and intents:
-the flat ``IntentDeterminationEngine``, the parallel
-``DomainIntentDeterminationEngine``, and a two-stage hierarchical router.
+This is NOT a benchmark. It is a small, hand-tuned dataset built to expose
+behavioural differences between three engine topologies — the flat
+``IntentDeterminationEngine``, the parallel ``DomainIntentDeterminationEngine``,
+and a two-stage hierarchical router. It is not a representative sample of real
+traffic; its accuracy numbers are an artifact of how the discriminating
+sections are mixed and can be skewed to favour any topology. See
+``docs/benchmark.md`` ("Reading the numbers").
 
 Design
 ------

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -15,16 +15,23 @@ two Adapt engine topologies on one shared keyword dataset:
 labelled utterances:
 
 ```text
-Cases   : 284  (217 match, 67 no-match)
+Cases   : 329  (249 match, 80 no-match)
 Intents : 22   across 10 domains
 Vocab   : 184 keyword samples across 28 entity types
 ```
 
 `TEST_CASES` are natural-language utterances — contractions, filler words,
-politeness markers, word-order variation — not template fills. The 67
-`NO_MATCH_UTTERANCES` are plausible but off-topic, many sharing surface words
-with real intents (e.g. *"the music at that restaurant was terrible"*) to
-stress-test the false-positive rate.
+politeness markers, word-order variation — not template fills. It includes a
+dedicated **entity-overlap** section: utterances built around words registered
+under two or more entity types spanning two or more domains (`turn up` is both
+a `VolumeKeyword` in *media* and a `HeatKeyword` in *climate*; `temperature` is
+both a `WeatherKeyword` and a `ThermostatKeyword`; `stop` / `cancel` / `kill`
+span *media*, *timers*, and *lights*). These are the only cases where a
+per-domain trie can tag an utterance differently from a shared trie.
+
+The 80 `NO_MATCH_UTTERANCES` are plausible but off-topic, many sharing surface
+words with real intents (e.g. *"the music just would not stop"*) to stress the
+false-positive rate.
 
 ## Metrics
 
@@ -32,6 +39,8 @@ stress-test the false-positive rate.
   correct when the engine returns nothing).
 - **Precision / Recall / F1** — over the match cases.
 - **TN / FP** — true negatives and false positives over the no-match cases.
+- **Head-to-head** — the cases where flat and domain predict a *different*
+  intent. This isolates the effect of trie isolation from the dataset.
 - **Latency** — per-query wall time.
 
 ## Results
@@ -40,33 +49,54 @@ Single run, both engines on the same machine and dataset:
 
 | Engine | Accuracy | Precision | Recall | F1 | TN/NM | FP | FN | Median lat |
 |---|---|---|---|---|---|---|---|---|
-| flat   | 80.3% | 81.0% | 90.3% | 0.854 | 32/67 | 46 | 21 | 0.18 ms |
-| domain | 80.6% | 81.4% | 90.8% | 0.858 | 32/67 | 45 | 20 | 0.74 ms |
+| flat   | 79.3% | 79.6% | 91.2% | 0.850 | 34/80 | 58 | 22 | 0.28 ms |
+| domain | 79.3% | 79.6% | 91.2% | 0.850 | 34/80 | 58 | 22 | 0.85 ms |
+
+Head-to-head:
+
+```text
+Cases             : 329
+Same prediction   : 318
+Different         :  11   (3.3%)
+```
+
+Of the 11 cases where the engines diverge: domain is correct on 4, flat is
+correct on 4, and both are wrong on 3 (a different false positive each).
 
 ## Interpreting the results
 
-**Domain grouping does not change matching quality here.** Accuracy,
-precision, recall, and the true-negative count are within one case of each
-other. Both engines reject the same 32 of 67 no-match utterances.
+**The engines are not identical, but neither is better.** Trie isolation does
+change the matched intent — on 11 of 329 cases (3.3%), all of them
+entity-overlap utterances. But the divergences cancel: every case domain wins,
+another case flat wins, so all aggregate metrics are equal to three decimals.
 
-The reason is structural. Adapt isolates vocabulary by giving each domain its
-own `Trie`, so a shared engine tags *more* entities in an utterance. But an
-intent parser only fires when **its own** required entity types are tagged —
-extra tags from unrelated intents do not satisfy a parser that needs a
-different type. Entity types are also globally named, so an entity carries
-the same type whether it is registered once or per domain. The extra tags a
-flat engine produces are therefore inert for parsers that gate on required
-types, and grouping changes neither the winning parse nor its confidence.
+**Why they diverge.** A domain sub-engine's `Trie` holds only the entity types
+its own intents declare. So a domain sub-engine tags *fewer* entities in an
+utterance than the shared flat trie does. Adapt confidence is driven by how
+much of the utterance tagged entities cover, so dropping foreign tags shifts
+the per-intent confidences and can flip the global argmax. Examples:
+
+- *"what are the symptoms of a cold"* — flat tags `cold` as a `WeatherKeyword`
+  and matches `weather_query`; the *information* sub-engine has no
+  `WeatherKeyword`, so `cold` is not tagged and `search_query` wins (domain
+  correct).
+- *"how warm is it today"* — flat matches `weather_query`; in domain mode the
+  *information* sub-engine scores `date_query` on `today` slightly higher than
+  the *weather* sub-engine scores `weather_query` on `warm`, and the global
+  argmax flips to `date_query` (domain wrong).
+
+The flip is a side effect of which entities happen to be visible, not a
+smarter decision — which is why the wins and losses come out even.
 
 **Domain routing costs latency.** The domain engine evaluates every domain's
-sub-engine per query, so median latency rises from ~0.18 ms to ~0.74 ms. Both
+sub-engine per query, so median latency rises from ~0.3 ms to ~0.85 ms. Both
 remain far below any perceptible threshold.
 
-**The false positives are inherent to keyword matching.** 35 of the 67
-no-match utterances trigger a parse under both engines because they contain a
-required keyword used outside a command context (*"i always stop for coffee"*,
-*"the forecast was wrong again"*). This is a property of keyword parsing, not
-of engine topology — domain grouping does not address it.
+**False positives are inherent to keyword matching.** 46 of the 80 no-match
+utterances trigger a parse under both engines because they contain a required
+keyword used outside a command context (*"the heating engineer came round"*,
+*"they cancel each other out"*). This is a property of keyword parsing, not of
+engine topology — domain grouping does not address it.
 
 ## When the domain engine is still useful
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -15,9 +15,11 @@ keyword dataset:
 - **domain** — a `DomainIntentDeterminationEngine`. Intents are grouped into
   domains; each domain owns an isolated sub-engine with its own `Trie` and
   tagger. Every domain is scored and the global argmax wins.
-- **hierarchical** — true two-stage routing. A stage-1 keyword-coverage
-  classifier picks one domain; stage 2 runs only that domain's sub-engine.
-  A wrong stage-1 route cannot be recovered.
+- **hierarchical** — a `HierarchicalIntentDeterminationEngine` (a subclass of
+  `DomainIntentDeterminationEngine` with the same registration API). Its
+  `determine_intent` runs a stage-1 keyword-coverage classifier to pick one
+  domain, then evaluates only that domain's sub-engine. A wrong stage-1 route
+  cannot be recovered.
 
 ## How the topologies can differ
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -8,10 +8,9 @@ Adapt engine topologies on one shared keyword dataset:
 - **domain** — a `DomainIntentDeterminationEngine`. Intents are grouped into
   domains; each domain owns an isolated sub-engine with its own `Trie` and
   tagger. Every domain is scored and the global argmax wins.
-- **hierarchical** — true two-stage routing. A stage-1 domain classifier (a
-  flat engine whose 'intents' are domains, each requiring a pooled keyword
-  entity covering every word the domain uses) picks one domain; stage 2 runs
-  only that domain's sub-engine. A wrong stage-1 route cannot be recovered.
+- **hierarchical** — true two-stage routing. A stage-1 keyword-coverage
+  classifier picks one domain; stage 2 runs only that domain's sub-engine.
+  A wrong stage-1 route cannot be recovered.
 
 ## Dataset
 
@@ -19,23 +18,20 @@ Adapt engine topologies on one shared keyword dataset:
 labelled utterances:
 
 ```text
-Cases   : 329  (249 match, 80 no-match)
-Intents : 22   across 10 domains
-Vocab   : 184 keyword samples across 28 entity types
+Cases   : 171  (125 match, 46 no-match)
+Intents : 26   across 11 domains
 ```
 
-`TEST_CASES` are natural-language utterances — contractions, filler words,
-politeness markers, word-order variation — not template fills. It includes a
-dedicated **entity-overlap** section: utterances built around words registered
-under two or more entity types spanning two or more domains (`turn up` is both
-a `VolumeKeyword` in *media* and a `HeatKeyword` in *climate*; `temperature` is
-both a `WeatherKeyword` and a `ThermostatKeyword`; `stop` / `cancel` / `kill`
-span *media*, *timers*, and *lights*). These are the only cases where a
-per-domain trie can tag an utterance differently from a shared trie.
+Intents are mostly **two-slot** — an ACTION keyword plus an OBJECT keyword
+(`turn` + `up` + `the` + `volume`), so a single stray keyword cannot trigger
+an intent on its own. OBJECT vocabularies are domain-distinctive (`thermostat`
+only appears in *climate*, `playlist` only in *media*); ACTION vocabularies are
+deliberately shared across domains (`turn up` is both a volume and a heating
+action). A few intents are genuinely single-trigger (`weather_query`,
+`navigate_to`, `get_help`) and stay one-slot.
 
-The 80 `NO_MATCH_UTTERANCES` are plausible but off-topic, many sharing surface
-words with real intents (e.g. *"the music just would not stop"*) to stress the
-false-positive rate.
+The 46 `NO_MATCH_UTTERANCES` are plausible but not commands, many containing a
+keyword used outside a command context (`"they cancel each other out"`).
 
 ## Metrics
 
@@ -55,86 +51,55 @@ Single run, all engines on the same machine and dataset:
 
 | Engine | Accuracy | Precision | Recall | F1 | TN/NM | FP | FN | Median lat |
 |---|---|---|---|---|---|---|---|---|
-| flat         | 79.3% | 79.6% | 91.2% | 0.850 | 34/80 | 58 | 22 | 0.23 ms |
-| domain       | 79.3% | 79.6% | 91.2% | 0.850 | 34/80 | 58 | 22 | 0.94 ms |
-| hierarchical | 74.5% | 80.2% | 81.5% | 0.809 | 42/80 | 50 | 46 | 0.38 ms |
+| flat         | 94.2% | 92.6% | 100.0% | 0.962 | 36/46 | 10 | 0 | 0.22 ms |
+| domain       | 94.2% | 92.6% | 100.0% | 0.962 | 36/46 | 10 | 0 | 0.82 ms |
+| hierarchical | 94.7% | 94.6% |  98.4% | 0.965 | 39/46 |  7 | 2 | 0.32 ms |
 
-Flat vs domain head-to-head:
+Flat vs domain head-to-head: **0 / 171 different** — identical predictions.
 
-```text
-Cases             : 329
-Same prediction   : 318
-Different         :  11   (3.3%)
-```
-
-Of the 11 cases where flat and domain diverge: domain is correct on 4, flat is
-correct on 4, and both are wrong on 3 (a different false positive each).
-
-Hierarchical stage-1 routing: **211 / 249 match cases (85%)** are routed to the
-correct domain. The other 15% are misrouted and cannot be recovered by stage 2.
+Hierarchical stage-1 routing: **123 / 125 match cases (98%)** routed to the
+correct domain.
 
 ## Interpreting the results
 
-**The engines are not identical, but neither is better.** Trie isolation does
-change the matched intent — on 11 of 329 cases (3.3%), all of them
-entity-overlap utterances. But the divergences cancel: every case domain wins,
-another case flat wins, so all aggregate metrics are equal to three decimals.
+**Flat and domain are identical.** With two-slot intents and domain-distinctive
+object vocabularies, the two engines agree on every one of the 171 cases. A
+parser only fires when its own required entity types are tagged; a domain
+sub-engine's trie holds exactly those types, so isolation removes only tags no
+parser would have used. `DomainIntentDeterminationEngine` is a packaging and
+lifecycle convenience here, not an accuracy change.
 
-**Why they diverge.** A domain sub-engine's `Trie` holds only the entity types
-its own intents declare. So a domain sub-engine tags *fewer* entities in an
-utterance than the shared flat trie does. Adapt confidence is driven by how
-much of the utterance tagged entities cover, so dropping foreign tags shifts
-the per-intent confidences and can flip the global argmax. Examples:
+**Two-stage routing trades recall for precision.** The hierarchical engine
+edges ahead — 94.7% vs 94.2% — but the gain is a precision/recall swap, not a
+free win:
 
-- *"what are the symptoms of a cold"* — flat tags `cold` as a `WeatherKeyword`
-  and matches `weather_query`; the *information* sub-engine has no
-  `WeatherKeyword`, so `cold` is not tagged and `search_query` wins (domain
-  correct).
-- *"how warm is it today"* — flat matches `weather_query`; in domain mode the
-  *information* sub-engine scores `date_query` on `today` slightly higher than
-  the *weather* sub-engine scores `weather_query` on `warm`, and the global
-  argmax flips to `date_query` (domain wrong).
+- It suppresses **3 false positives**. Each is a no-match utterance containing
+  a bare keyword for a *single-slot* intent — `"they cancel each other out"`,
+  `"stop right there"`, `"can you cancel it"`. Flat fires `stop_all` on the
+  lone `stop` / `cancel`. The classifier routes these to a *two-slot* domain
+  (*media* or *timers*), whose intents need a second keyword that is absent, so
+  nothing fires and no false positive is emitted. FP drops 10 → 7, precision
+  rises 92.6% → 94.6%.
+- It costs **2 false negatives**. Bare `"stop"` and `"cancel"`, issued as real
+  `stop_all` commands, are routed by the *same* mechanism to a domain that does
+  not own `stop_all`, so the command is lost. Recall drops 100% → 98.4%.
 
-The flip is a side effect of which entities happen to be visible, not a
-smarter decision — which is why the wins and losses come out even.
+Both effects come from one cause: a one-word utterance gives the stage-1
+classifier nothing to disambiguate, so it routes by a vocabulary-overlap
+tie-break. When the utterance is genuinely off-topic that accidentally helps;
+when it is a real command it hurts. Two-stage routing cannot recover an
+utterance whose domain is ambiguous from its own text.
 
-**Two-stage routing is worse, not better.** The hierarchical engine scores
-74.5% — five points below flat — because hard stage-1 routing is lossy.
-Stage 1 misroutes 15% of match cases, and a misrouted utterance is
-unrecoverable: stage 2 only ever sees one domain. Recall drops from 91.2% to
-81.5% as a direct result.
+**Routing must be reliable for two-stage to be viable.** Stage 1 here is a
+keyword-coverage classifier and routes 98% of match cases correctly — only
+because the dataset's OBJECT vocabularies are domain-distinctive. With muddy,
+overlapping domain vocabulary the router degrades and every misroute is an
+unrecoverable error; two-stage is only worth it when domains are lexically
+separable.
 
-This is structural, not a tuning problem. Flat global-argmax already considers
-every intent, so it is an *upper bound* that hard two-stage routing cannot
-exceed — two-stage only ever removes candidates. The misroutes are caused by
-the same shared vocabulary the overlap cases stress: `cancel the timer` routes
-to *media* because `cancel` is a `StopKeyword` there, never reaching the
-*timers* domain that owns `cancel_timer`.
-
-Hierarchical does buy a little precision: the stage-1 gate rejects 8 more
-no-match utterances (TN 34 → 42, FP 58 → 50), lifting precision to 80.2%. But
-the recall it sacrifices to get there costs far more accuracy than the
-precision it gains. It is also faster than the parallel domain engine
-(~0.38 ms vs ~0.94 ms) because stage 2 evaluates only one sub-engine — but
-speed was never the bottleneck.
-
-**Domain routing costs latency.** The parallel domain engine evaluates every
-domain's sub-engine per query, so median latency rises from ~0.2 ms to
-~0.9 ms. Both remain far below any perceptible threshold.
-
-**False positives are inherent to keyword matching.** 46 of the 80 no-match
-utterances trigger a parse under both engines because they contain a required
-keyword used outside a command context (*"the heating engineer came round"*,
-*"they cancel each other out"*). This is a property of keyword parsing, not of
-engine topology — domain grouping does not address it.
-
-## When the domain engine is still useful
-
-The benchmark measures accuracy, not lifecycle. `DomainIntentDeterminationEngine`
-keeps each domain's parsers, entities, and regexes in a separate sub-engine,
-which makes it cheap to add or drop a whole domain at runtime (`remove_domain`)
-without rebuilding a shared `Trie`. That is an operational benefit; it does not
-show up as an accuracy difference.
+**Latency.** Flat is fastest (~0.2 ms). Hierarchical (~0.3 ms) runs a cheap
+classifier plus one sub-engine. The parallel domain engine (~0.8 ms) evaluates
+every sub-engine per query. All are far below any perceptible threshold.
 
 ## How to run
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,83 @@
+# Benchmark
+
+`benchmark/compare.py` measures intent-matching accuracy and speed of the
+two Adapt engine topologies on one shared keyword dataset:
+
+- **flat** — a single `IntentDeterminationEngine`. Every intent parser and
+  every entity share one `Trie` and one entity tagger.
+- **domain** — a `DomainIntentDeterminationEngine`. Intents are grouped into
+  domains; each domain owns an isolated sub-engine with its own `Trie` and
+  tagger. Every domain is scored and the global argmax wins.
+
+## Dataset
+
+`benchmark/dataset.py` defines the vocabulary, intents, domain grouping, and
+labelled utterances:
+
+```text
+Cases   : 284  (217 match, 67 no-match)
+Intents : 22   across 10 domains
+Vocab   : 184 keyword samples across 28 entity types
+```
+
+`TEST_CASES` are natural-language utterances — contractions, filler words,
+politeness markers, word-order variation — not template fills. The 67
+`NO_MATCH_UTTERANCES` are plausible but off-topic, many sharing surface words
+with real intents (e.g. *"the music at that restaurant was terrible"*) to
+stress-test the false-positive rate.
+
+## Metrics
+
+- **Accuracy** — correct predictions over all cases (a no-match case is
+  correct when the engine returns nothing).
+- **Precision / Recall / F1** — over the match cases.
+- **TN / FP** — true negatives and false positives over the no-match cases.
+- **Latency** — per-query wall time.
+
+## Results
+
+Single run, both engines on the same machine and dataset:
+
+| Engine | Accuracy | Precision | Recall | F1 | TN/NM | FP | FN | Median lat |
+|---|---|---|---|---|---|---|---|---|
+| flat   | 80.3% | 81.0% | 90.3% | 0.854 | 32/67 | 46 | 21 | 0.18 ms |
+| domain | 80.6% | 81.4% | 90.8% | 0.858 | 32/67 | 45 | 20 | 0.74 ms |
+
+## Interpreting the results
+
+**Domain grouping does not change matching quality here.** Accuracy,
+precision, recall, and the true-negative count are within one case of each
+other. Both engines reject the same 32 of 67 no-match utterances.
+
+The reason is structural. Adapt isolates vocabulary by giving each domain its
+own `Trie`, so a shared engine tags *more* entities in an utterance. But an
+intent parser only fires when **its own** required entity types are tagged —
+extra tags from unrelated intents do not satisfy a parser that needs a
+different type. Entity types are also globally named, so an entity carries
+the same type whether it is registered once or per domain. The extra tags a
+flat engine produces are therefore inert for parsers that gate on required
+types, and grouping changes neither the winning parse nor its confidence.
+
+**Domain routing costs latency.** The domain engine evaluates every domain's
+sub-engine per query, so median latency rises from ~0.18 ms to ~0.74 ms. Both
+remain far below any perceptible threshold.
+
+**The false positives are inherent to keyword matching.** 35 of the 67
+no-match utterances trigger a parse under both engines because they contain a
+required keyword used outside a command context (*"i always stop for coffee"*,
+*"the forecast was wrong again"*). This is a property of keyword parsing, not
+of engine topology — domain grouping does not address it.
+
+## When the domain engine is still useful
+
+The benchmark measures accuracy, not lifecycle. `DomainIntentDeterminationEngine`
+keeps each domain's parsers, entities, and regexes in a separate sub-engine,
+which makes it cheap to add or drop a whole domain at runtime (`remove_domain`)
+without rebuilding a shared `Trie`. That is an operational benefit; it does not
+show up as an accuracy difference.
+
+## How to run
+
+```bash
+python benchmark/compare.py
+```

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,13 +1,17 @@
 # Benchmark
 
-`benchmark/compare.py` measures intent-matching accuracy and speed of the
-two Adapt engine topologies on one shared keyword dataset:
+`benchmark/compare.py` measures intent-matching accuracy and speed of three
+Adapt engine topologies on one shared keyword dataset:
 
 - **flat** — a single `IntentDeterminationEngine`. Every intent parser and
   every entity share one `Trie` and one entity tagger.
 - **domain** — a `DomainIntentDeterminationEngine`. Intents are grouped into
   domains; each domain owns an isolated sub-engine with its own `Trie` and
   tagger. Every domain is scored and the global argmax wins.
+- **hierarchical** — true two-stage routing. A stage-1 domain classifier (a
+  flat engine whose 'intents' are domains, each requiring a pooled keyword
+  entity covering every word the domain uses) picks one domain; stage 2 runs
+  only that domain's sub-engine. A wrong stage-1 route cannot be recovered.
 
 ## Dataset
 
@@ -41,18 +45,21 @@ false-positive rate.
 - **TN / FP** — true negatives and false positives over the no-match cases.
 - **Head-to-head** — the cases where flat and domain predict a *different*
   intent. This isolates the effect of trie isolation from the dataset.
+- **Stage-1 routing** — for the hierarchical engine, the share of match cases
+  whose stage-1 classifier picked the domain that owns the correct intent.
 - **Latency** — per-query wall time.
 
 ## Results
 
-Single run, both engines on the same machine and dataset:
+Single run, all engines on the same machine and dataset:
 
 | Engine | Accuracy | Precision | Recall | F1 | TN/NM | FP | FN | Median lat |
 |---|---|---|---|---|---|---|---|---|
-| flat   | 79.3% | 79.6% | 91.2% | 0.850 | 34/80 | 58 | 22 | 0.28 ms |
-| domain | 79.3% | 79.6% | 91.2% | 0.850 | 34/80 | 58 | 22 | 0.85 ms |
+| flat         | 79.3% | 79.6% | 91.2% | 0.850 | 34/80 | 58 | 22 | 0.23 ms |
+| domain       | 79.3% | 79.6% | 91.2% | 0.850 | 34/80 | 58 | 22 | 0.94 ms |
+| hierarchical | 74.5% | 80.2% | 81.5% | 0.809 | 42/80 | 50 | 46 | 0.38 ms |
 
-Head-to-head:
+Flat vs domain head-to-head:
 
 ```text
 Cases             : 329
@@ -60,8 +67,11 @@ Same prediction   : 318
 Different         :  11   (3.3%)
 ```
 
-Of the 11 cases where the engines diverge: domain is correct on 4, flat is
+Of the 11 cases where flat and domain diverge: domain is correct on 4, flat is
 correct on 4, and both are wrong on 3 (a different false positive each).
+
+Hierarchical stage-1 routing: **211 / 249 match cases (85%)** are routed to the
+correct domain. The other 15% are misrouted and cannot be recovered by stage 2.
 
 ## Interpreting the results
 
@@ -88,9 +98,29 @@ the per-intent confidences and can flip the global argmax. Examples:
 The flip is a side effect of which entities happen to be visible, not a
 smarter decision — which is why the wins and losses come out even.
 
-**Domain routing costs latency.** The domain engine evaluates every domain's
-sub-engine per query, so median latency rises from ~0.3 ms to ~0.85 ms. Both
-remain far below any perceptible threshold.
+**Two-stage routing is worse, not better.** The hierarchical engine scores
+74.5% — five points below flat — because hard stage-1 routing is lossy.
+Stage 1 misroutes 15% of match cases, and a misrouted utterance is
+unrecoverable: stage 2 only ever sees one domain. Recall drops from 91.2% to
+81.5% as a direct result.
+
+This is structural, not a tuning problem. Flat global-argmax already considers
+every intent, so it is an *upper bound* that hard two-stage routing cannot
+exceed — two-stage only ever removes candidates. The misroutes are caused by
+the same shared vocabulary the overlap cases stress: `cancel the timer` routes
+to *media* because `cancel` is a `StopKeyword` there, never reaching the
+*timers* domain that owns `cancel_timer`.
+
+Hierarchical does buy a little precision: the stage-1 gate rejects 8 more
+no-match utterances (TN 34 → 42, FP 58 → 50), lifting precision to 80.2%. But
+the recall it sacrifices to get there costs far more accuracy than the
+precision it gains. It is also faster than the parallel domain engine
+(~0.38 ms vs ~0.94 ms) because stage 2 evaluates only one sub-engine — but
+speed was never the bottleneck.
+
+**Domain routing costs latency.** The parallel domain engine evaluates every
+domain's sub-engine per query, so median latency rises from ~0.2 ms to
+~0.9 ms. Both remain far below any perceptible threshold.
 
 **False positives are inherent to keyword matching.** 46 of the 80 no-match
 utterances trigger a parse under both engines because they contain a required

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -12,38 +12,50 @@ Adapt engine topologies on one shared keyword dataset:
   classifier picks one domain; stage 2 runs only that domain's sub-engine.
   A wrong stage-1 route cannot be recovered.
 
+## How the topologies can differ
+
+Adapt scores a parse with
+`confidence = intent_confidence / len(clique_tags) × clique_confidence`,
+where `clique_tags` is *every* entity tagged in the matched clique — including
+entities from unrelated intents. So an intent's confidence is **diluted by the
+number of foreign tags** sharing its clique.
+
+- **flat** tags an utterance against every domain's vocabulary at once, so
+  cliques carry the most foreign tags and dilute the most.
+- **domain** tags each utterance against one domain's vocabulary at a time, so
+  cliques are smaller and the in-domain intent is diluted less.
+- **hierarchical** additionally discards every domain but one before scoring.
+
+On a clean single-intent utterance all three pick the same winner — there is
+no competitor for dilution to reorder. They diverge on utterances that carry
+more than one intent's keywords.
+
 ## Dataset
 
 `benchmark/dataset.py` defines the vocabulary, intents, domain grouping, and
 labelled utterances:
 
 ```text
-Cases   : 171  (125 match, 46 no-match)
+Cases   : 195  (139 match, 56 no-match)
 Intents : 26   across 11 domains
 ```
 
-Intents are mostly **two-slot** — an ACTION keyword plus an OBJECT keyword
-(`turn` + `up` + `the` + `volume`), so a single stray keyword cannot trigger
-an intent on its own. OBJECT vocabularies are domain-distinctive (`thermostat`
-only appears in *climate*, `playlist` only in *media*); ACTION vocabularies are
-deliberately shared across domains (`turn up` is both a volume and a heating
-action). A few intents are genuinely single-trigger (`weather_query`,
-`navigate_to`, `get_help`) and stay one-slot.
+Intents are mostly **two-slot** — a shared ACTION keyword plus a
+domain-distinctive OBJECT keyword — so a single stray keyword cannot trigger an
+intent. Beyond the everyday cases, the dataset carries three hand-crafted
+discriminating sections, each built to give one topology a clear edge:
 
-The 46 `NO_MATCH_UTTERANCES` are plausible but not commands, many containing a
-keyword used outside a command context (`"they cancel each other out"`).
-
-## Metrics
-
-- **Accuracy** — correct predictions over all cases (a no-match case is
-  correct when the engine returns nothing).
-- **Precision / Recall / F1** — over the match cases.
-- **TN / FP** — true negatives and false positives over the no-match cases.
-- **Head-to-head** — the cases where flat and domain predict a *different*
-  intent. This isolates the effect of trie isolation from the dataset.
-- **Stage-1 routing** — for the hierarchical engine, the share of match cases
-  whose stage-1 classifier picked the domain that owns the correct intent.
-- **Latency** — per-query wall time.
+- **flat & domain win, hierarchical loses** — real commands carrying a long
+  room/topic word (or a bare one-word command) that pulls the stage-1
+  classifier to the wrong domain. The misroute is unrecoverable.
+- **flat and domain diverge** — two-clause utterances carrying two intents,
+  labelled by the leading clause. Flat scores both clauses in one shared
+  clique; domain scores each clause in its own sub-engine. The dilution term
+  breaks the clause tie differently.
+- **hierarchical wins, flat & domain lose** — utterances that are not commands
+  but contain a bare keyword for a single-slot intent. Flat and domain fire on
+  the lone word; the classifier routes them to a two-slot domain where the
+  missing second keyword means nothing fires.
 
 ## Results
 
@@ -51,51 +63,43 @@ Single run, all engines on the same machine and dataset:
 
 | Engine | Accuracy | Precision | Recall | F1 | TN/NM | FP | FN | Median lat |
 |---|---|---|---|---|---|---|---|---|
-| flat         | 94.2% | 92.6% | 100.0% | 0.962 | 36/46 | 10 | 0 | 0.22 ms |
-| domain       | 94.2% | 92.6% | 100.0% | 0.962 | 36/46 | 10 | 0 | 0.82 ms |
-| hierarchical | 94.7% | 94.6% |  98.4% | 0.965 | 39/46 |  7 | 2 | 0.32 ms |
+| flat         | 87.2% | 84.3% | 96.4% | 0.899 | 36/56 | 25 |  5 | 0.21 ms |
+| domain       | 88.2% | 85.5% | 97.8% | 0.913 | 36/56 | 23 |  3 | 0.82 ms |
+| hierarchical | 90.3% | 93.4% | 91.4% | 0.924 | 49/56 |  9 | 12 | 0.32 ms |
 
-Flat vs domain head-to-head: **0 / 171 different** — identical predictions.
+Flat vs domain head-to-head: **6 / 195 different** — all six the two-clause
+utterances. Flat resolves the leading clause on 2 of them, domain on all 6.
 
-Hierarchical stage-1 routing: **123 / 125 match cases (98%)** routed to the
+Hierarchical stage-1 routing: **127 / 139 match cases (91%)** routed to the
 correct domain.
 
 ## Interpreting the results
 
-**Flat and domain are identical.** With two-slot intents and domain-distinctive
-object vocabularies, the two engines agree on every one of the 171 cases. A
-parser only fires when its own required entity types are tagged; a domain
-sub-engine's trie holds exactly those types, so isolation removes only tags no
-parser would have used. `DomainIntentDeterminationEngine` is a packaging and
-lifecycle convenience here, not an accuracy change.
+**Flat and domain are not equivalent.** They agree on every clean single-intent
+utterance — correctly, since dilution cannot reorder an uncontested winner —
+but diverge on the two-clause cases. There, flat scores both clauses inside one
+clique whose tag count dilutes them equally, and the tie falls to the
+higher-coverage (usually later, longer) clause. Domain scores each clause in
+its own sub-engine, where the leading clause's intent stands alone and is
+diluted less. Domain resolves the labelled (leading) intent on all 6; flat on
+2. Domain ends 1 point ahead overall (88.2% vs 87.2%) with fewer false
+positives and false negatives.
 
-**Two-stage routing trades recall for precision.** The hierarchical engine
-edges ahead — 94.7% vs 94.2% — but the gain is a precision/recall swap, not a
-free win:
+**Hierarchical trades recall for precision, and here comes out ahead.** Its
+stage-1 gate cuts false positives from ~24 to 9 (true negatives 36 → 49): a
+no-match utterance carrying a bare `stop` / `cancel` is routed to a two-slot
+domain where nothing fires, so no intent is emitted. That lifts precision to
+93.4%. The cost is recall: 12 false negatives, because a real command that the
+classifier misroutes — a one-word command, or one carrying a long room word
+that outweighs the intent keyword — is unrecoverable. On this dataset the
+precision gain outweighs the recall loss and hierarchical leads at 90.3%, but
+that balance depends entirely on how command-like the no-match traffic is.
 
-- It suppresses **3 false positives**. Each is a no-match utterance containing
-  a bare keyword for a *single-slot* intent — `"they cancel each other out"`,
-  `"stop right there"`, `"can you cancel it"`. Flat fires `stop_all` on the
-  lone `stop` / `cancel`. The classifier routes these to a *two-slot* domain
-  (*media* or *timers*), whose intents need a second keyword that is absent, so
-  nothing fires and no false positive is emitted. FP drops 10 → 7, precision
-  rises 92.6% → 94.6%.
-- It costs **2 false negatives**. Bare `"stop"` and `"cancel"`, issued as real
-  `stop_all` commands, are routed by the *same* mechanism to a domain that does
-  not own `stop_all`, so the command is lost. Recall drops 100% → 98.4%.
-
-Both effects come from one cause: a one-word utterance gives the stage-1
-classifier nothing to disambiguate, so it routes by a vocabulary-overlap
-tie-break. When the utterance is genuinely off-topic that accidentally helps;
-when it is a real command it hurts. Two-stage routing cannot recover an
-utterance whose domain is ambiguous from its own text.
-
-**Routing must be reliable for two-stage to be viable.** Stage 1 here is a
-keyword-coverage classifier and routes 98% of match cases correctly — only
-because the dataset's OBJECT vocabularies are domain-distinctive. With muddy,
-overlapping domain vocabulary the router degrades and every misroute is an
-unrecoverable error; two-stage is only worth it when domains are lexically
-separable.
+**Routing must be reliable for two-stage to pay off.** Stage 1 routes 91% of
+match cases correctly. Every one of the 9% misroutes is an unrecoverable error.
+Two-stage is only viable when domain vocabularies are distinctive enough to
+classify; the discriminating section deliberately includes utterances where
+they are not, and hierarchical loses exactly those.
 
 **Latency.** Flat is fastest (~0.2 ms). Hierarchical (~0.3 ms) runs a cheap
 classifier plus one sub-engine. The parallel domain engine (~0.8 ms) evaluates

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,7 +1,14 @@
-# Benchmark
+# Engine comparison reference
 
-`benchmark/compare.py` measures intent-matching accuracy and speed of three
-Adapt engine topologies on one shared keyword dataset:
+> **This is not a benchmark.** `benchmark/dataset.py` is a small, hand-tuned
+> reference corpus built to *expose behavioural differences* between the three
+> Adapt engine topologies. It is not a representative sample of real traffic,
+> and the headline accuracy numbers below are an artifact of how the dataset is
+> composed — see [Reading the numbers](#reading-the-numbers). Use it to
+> understand *how* the topologies diverge and *why*, not to rank them.
+
+`benchmark/compare.py` runs three Adapt engine topologies on one shared
+keyword dataset:
 
 - **flat** — a single `IntentDeterminationEngine`. Every intent parser and
   every entity share one `Trie` and one entity tagger.
@@ -27,8 +34,8 @@ number of foreign tags** sharing its clique.
 - **hierarchical** additionally discards every domain but one before scoring.
 
 On a clean single-intent utterance all three pick the same winner — there is
-no competitor for dilution to reorder. They diverge on utterances that carry
-more than one intent's keywords.
+no competitor for dilution to reorder. They diverge only on utterances that
+carry more than one intent's keywords, or that the stage-1 router misroutes.
 
 ## Dataset
 
@@ -41,9 +48,9 @@ Intents : 26   across 11 domains
 ```
 
 Intents are mostly **two-slot** — a shared ACTION keyword plus a
-domain-distinctive OBJECT keyword — so a single stray keyword cannot trigger an
-intent. Beyond the everyday cases, the dataset carries three hand-crafted
-discriminating sections, each built to give one topology a clear edge:
+domain-distinctive OBJECT keyword. Beyond the everyday cases, the dataset
+carries three hand-crafted discriminating sections, each *deliberately
+constructed* to give one topology an edge:
 
 - **flat & domain win, hierarchical loses** — real commands carrying a long
   room/topic word (or a bare one-word command) that pulls the stage-1
@@ -73,33 +80,59 @@ utterances. Flat resolves the leading clause on 2 of them, domain on all 6.
 Hierarchical stage-1 routing: **127 / 139 match cases (91%)** routed to the
 correct domain.
 
-## Interpreting the results
+## Reading the numbers
+
+**The accuracy ordering is something this dataset was built to produce, not a
+property of the engines.** The three discriminating sections each move the
+result a fixed amount, so the headline ranking is whatever their proportions
+make it. The dataset can be tuned to crown any engine:
+
+- **To make hierarchical win** — add more bare-keyword non-commands
+  (`"they cancel each other out"`). Each is a false positive flat and domain
+  emit and hierarchical's gate suppresses. The current dataset has ten; doubling
+  them widens hierarchical's lead.
+- **To make hierarchical lose** — add more routing-hard commands: one-word
+  utterances, or commands carrying a long off-domain word that outweighs the
+  intent keyword in the stage-1 classifier. Each is an unrecoverable misroute,
+  a false negative only hierarchical suffers.
+- **To separate flat from domain** — add more two-clause utterances. Domain
+  resolves the leading clause more often, so each case widens domain's margin.
+  Remove them and flat and domain are once again indistinguishable.
+- **To erase all differences** — keep only clean single-intent commands with
+  distinctive per-domain vocabulary. Dilution cannot reorder an uncontested
+  winner, so all three topologies score identically. An earlier revision of
+  this dataset did exactly that and reported flat ≡ domain ≡ hierarchical.
+
+The same freedom applies to the vocabulary: sharing a keyword across domains
+(`temperature` here is both a weather and a climate word) manufactures
+cross-domain competition; keeping every object word domain-unique removes it.
+Optional slots, keyword lengths, and how intents are grouped into domains all
+shift the confidence arithmetic.
+
+So treat the table as a description of *behaviour* — flat dilutes most, domain
+dilutes less, hierarchical gates false positives at the cost of misroutes — not
+as a measurement of accuracy. A real accuracy figure requires a corpus sampled
+from production traffic, with the section mix reflecting how often each
+situation actually occurs. This dataset makes no such claim.
+
+## Interpreting the divergences
 
 **Flat and domain are not equivalent.** They agree on every clean single-intent
 utterance — correctly, since dilution cannot reorder an uncontested winner —
 but diverge on the two-clause cases. There, flat scores both clauses inside one
 clique whose tag count dilutes them equally, and the tie falls to the
-higher-coverage (usually later, longer) clause. Domain scores each clause in
-its own sub-engine, where the leading clause's intent stands alone and is
-diluted less. Domain resolves the labelled (leading) intent on all 6; flat on
-2. Domain ends 1 point ahead overall (88.2% vs 87.2%) with fewer false
-positives and false negatives.
+higher-coverage clause. Domain scores each clause in its own sub-engine, where
+the leading clause's intent stands alone and is diluted less.
 
-**Hierarchical trades recall for precision, and here comes out ahead.** Its
-stage-1 gate cuts false positives from ~24 to 9 (true negatives 36 → 49): a
-no-match utterance carrying a bare `stop` / `cancel` is routed to a two-slot
-domain where nothing fires, so no intent is emitted. That lifts precision to
-93.4%. The cost is recall: 12 false negatives, because a real command that the
-classifier misroutes — a one-word command, or one carrying a long room word
-that outweighs the intent keyword — is unrecoverable. On this dataset the
-precision gain outweighs the recall loss and hierarchical leads at 90.3%, but
-that balance depends entirely on how command-like the no-match traffic is.
+**Hierarchical trades recall for precision.** Its stage-1 gate suppresses false
+positives (a no-match utterance carrying a bare `stop` / `cancel` is routed to
+a two-slot domain where nothing fires) but cannot recover a real command the
+classifier misroutes. Whether that trade is net positive depends entirely on
+how command-like the no-match traffic is — i.e. on the dataset.
 
-**Routing must be reliable for two-stage to pay off.** Stage 1 routes 91% of
-match cases correctly. Every one of the 9% misroutes is an unrecoverable error.
-Two-stage is only viable when domain vocabularies are distinctive enough to
-classify; the discriminating section deliberately includes utterances where
-they are not, and hierarchical loses exactly those.
+**Routing must be reliable for two-stage to pay off.** Every stage-1 misroute
+is an unrecoverable error. Two-stage is only viable when domain vocabularies
+are distinctive enough to classify.
 
 **Latency.** Flat is fastest (~0.2 ms). Hierarchical (~0.3 ms) runs a cheap
 classifier plus one sub-engine. The parallel domain engine (~0.8 ms) evaluates

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,15 +1,20 @@
 # Configuration
 
-## Entry point
+## Entry points
 
-The plugin is published under the OPM `opm.pipeline` entry point:
+The package publishes three OPM `opm.pipeline` entry points — the flat plugin
+and two domain-organised variants:
 
 ```toml
 [project.entry-points."opm.pipeline"]
 "ovos-adapt-pipeline-plugin" = "ovos_adapt.opm:AdaptPipeline"
+"ovos-adapt-domain-pipeline-plugin" = "ovos_adapt.opm:DomainAdaptPipeline"
+"ovos-adapt-hierarchical-pipeline-plugin" = "ovos_adapt.opm:HierarchicalAdaptPipeline"
 ```
 
-OVOS discovers it by that id — `ovos-adapt-pipeline-plugin`.
+OVOS discovers each by its id. This page covers the flat
+`ovos-adapt-pipeline-plugin`; the variants behave the same way and accept the
+same keys in their own config sections — see [Pipeline variants](pipelines.md).
 
 ## Enabling it in the pipeline
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,10 @@ start at [Concepts](concepts.md). If you just want it running, jump to the
 
 **Building on or extending the plugin:**
 
-5. [Bus protocol](bus-protocol.md) — the messagebus API skills use to register
-6. [Internals](internals.md) — the tagger, clique expansion, the confidence math
+5. [Pipeline variants](pipelines.md) — the flat, domain, and hierarchical plugins
+6. [Bus protocol](bus-protocol.md) — the messagebus API skills use to register
+7. [Internals](internals.md) — the tagger, clique expansion, the confidence math
+8. [Engine comparison reference](benchmark.md) — how the variants diverge
 
 ## At a glance
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -90,18 +90,28 @@ Add an unrelated registered word — say `play` — and a fourth tag appears.
 though the command is unchanged. This dilution is the main reason scores differ
 between engine topologies (see below).
 
-## DomainIntentDeterminationEngine
+## Domain engines
 
-`DomainIntentDeterminationEngine` groups intents into **domains**, each backed
-by its own `IntentDeterminationEngine` — its own Trie, tagger, and parser set.
-Registration takes a `domain=` argument; `determine_intent` scores every domain
-and the caller takes the global argmax.
+Two engine classes group intents into **domains** — each domain backed by its
+own `IntentDeterminationEngine` (its own Trie, tagger, and parser set).
+Registration takes a `domain=` argument.
 
-Because each domain tags against only its own vocabulary, a domain's cliques
-carry fewer foreign tags, so the `len(tags)` dilution above is smaller than in a
-single flat engine. On a clean single-intent utterance this changes the score
-but not the winner; on utterances carrying several intents' keywords it can
-change which intent wins.
+**`DomainIntentDeterminationEngine`** scores every domain and the caller takes
+the global argmax. Because each domain tags against only its own vocabulary, a
+domain's cliques carry fewer foreign tags, so the `len(tags)` dilution above is
+smaller than in a single flat engine. On a clean single-intent utterance this
+changes the score but not the winner; on utterances carrying several intents'
+keywords it can change which intent wins.
+
+**`HierarchicalIntentDeterminationEngine`** subclasses the above and keeps the
+same registration API. Its `determine_intent` is two-stage: a `classify_domain`
+keyword-coverage classifier picks a single domain, then only that domain's
+sub-engine is scored. A misrouted domain cannot be recovered.
+
+The `DomainAdaptPipeline` and `HierarchicalAdaptPipeline` plugins wrap these two
+engines — see [Pipeline variants](pipelines.md). The
+[engine comparison reference](benchmark.md) measures how the three topologies
+diverge and explains why.
 
 ## Context
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,0 +1,63 @@
+# Pipeline variants
+
+The package ships **three** OPM pipeline plugins. All match intents with the
+same Adapt engine and expose the same bus protocol; they differ only in how
+intents are *organised* and *scored*.
+
+| Plugin class | Entry-point id | Config section |
+|---|---|---|
+| `AdaptPipeline` | `ovos-adapt-pipeline-plugin` | `intents.ovos-adapt-pipeline-plugin` |
+| `DomainAdaptPipeline` | `ovos-adapt-domain-pipeline-plugin` | `intents.ovos_adapt_domain_pipeline` |
+| `HierarchicalAdaptPipeline` | `ovos-adapt-hierarchical-pipeline-plugin` | `intents.ovos_adapt_hierarchical_pipeline` |
+
+Each is selected by adding its id (with a `-high` / `-medium` / `-low` tier
+suffix) to `intents.pipeline` — see [Configuration](configuration.md). They can
+coexist; each reads its own config section.
+
+## flat — `AdaptPipeline`
+
+One `IntentDeterminationEngine`. Every intent parser and every entity share a
+single Trie and tagger. This is the default and the right choice for almost all
+installs.
+
+## domain — `DomainAdaptPipeline`
+
+A `DomainIntentDeterminationEngine`. Intents are grouped into **domains** — one
+per `skill_id`, taken from the `skill_id:intent_name` label — and each domain
+gets its own isolated sub-engine (its own Trie and tagger). At match time every
+domain is scored and the global argmax wins.
+
+Isolating each skill's vocabulary in its own Trie means a domain's parses carry
+fewer foreign tags. Because Adapt's confidence divides by the total tag count of
+a parse (see [Internals](internals.md)), less foreign vocabulary means less
+dilution. On a clean single-intent command this changes the score but not the
+winner; it can matter on utterances that carry several skills' keywords.
+
+## hierarchical — `HierarchicalAdaptPipeline`
+
+A `HierarchicalIntentDeterminationEngine` — the same per-skill domain model as
+above, but two-stage. A stage-1 keyword-coverage classifier picks **one** domain
+first, then only that domain's sub-engine is scored. A misrouted domain cannot
+be recovered, so this trades recall (a wrong route loses the command) for
+precision (a stray keyword routed to an unrelated domain triggers nothing).
+
+## Which should I use?
+
+Use the **flat** `AdaptPipeline` unless you have a specific reason not to. The
+domain and hierarchical variants change *how* matching is organised, not its
+correctness; whether they help depends on your skill mix and how command-like
+your false traffic is. The differences — and how they can be measured or
+misrepresented — are covered in detail in the
+[engine comparison reference](benchmark.md).
+
+## Engine classes
+
+All three pipelines are thin wrappers over engine classes in
+`ovos_adapt.engine`, which can be used standalone:
+
+- `IntentDeterminationEngine` — flat
+- `DomainIntentDeterminationEngine` — per-domain, parallel argmax
+- `HierarchicalIntentDeterminationEngine` — per-domain, two-stage routing
+
+See [Internals](internals.md) and [Quickstart](quickstart.md) for direct engine
+use.

--- a/ovos_adapt/engine.py
+++ b/ovos_adapt/engine.py
@@ -535,3 +535,80 @@ class DomainIntentDeterminationEngine(object):
         """
         return self.domains[domain].drop_regex_entity(entity_type=entity_type,
                                                       match_func=match_func)
+
+
+class HierarchicalIntentDeterminationEngine(DomainIntentDeterminationEngine):
+    """Two-stage domain engine: classify the domain, then resolve the intent.
+
+    Shares the registration API of :class:`DomainIntentDeterminationEngine`.
+    Where that engine scores every domain in parallel and takes the global
+    argmax, :meth:`determine_intent` here first picks a single domain with a
+    keyword-coverage classifier and evaluates only that domain's sub-engine.
+    A misclassified domain cannot be recovered.
+    """
+
+    def __init__(self):
+        super().__init__()
+        #: domain -> set of registered entity surface forms, scored by the
+        #: stage-1 classifier.
+        self._domain_vocabulary = {}
+
+    def register_entity(self, entity_value, entity_type, alias_of=None,
+                        domain=0):
+        """Register an entity and record its surface form for the classifier."""
+        super().register_entity(entity_value, entity_type,
+                                alias_of=alias_of, domain=domain)
+        self._domain_vocabulary.setdefault(domain, set()).add(
+            entity_value.lower())
+
+    def classify_domain(self, utterance):
+        """Return the domain whose vocabulary best covers the utterance.
+
+        Scores each domain by the number of utterance characters covered by
+        its registered entity values, word-boundary matched.
+
+        Args:
+            utterance(str): the utterance to classify.
+
+        Returns:
+            The best-matching domain, or ``None`` when no domain keyword is
+            present.
+        """
+        text = utterance.lower()
+        best_domain = None
+        best_score = 0
+        for domain, vocabulary in self._domain_vocabulary.items():
+            if domain not in self.domains:
+                continue
+            covered = bytearray(len(text))
+            for keyword in vocabulary:
+                for match in re.finditer(
+                        r"\b" + re.escape(keyword) + r"\b", text):
+                    for i in range(match.start(), match.end()):
+                        covered[i] = 1
+            score = sum(covered)
+            if score > best_score:
+                best_score = score
+                best_domain = domain
+        return best_domain
+
+    def determine_intent(self, utterance, num_results=1, include_tags=False,
+                         context_manager=None):
+        """Classify the domain, then yield intents from that domain only.
+
+        Args:
+            utterance(str): an ascii or unicode string representing natural
+                language speech.
+            num_results(int): a maximum number of results to be returned.
+            include_tags(bool): include the parsed tags as part of result.
+            context_manager(list): a context manager to provide context.
+
+        Returns: A generator that yields dictionaries.
+        """
+        domain = self.classify_domain(utterance)
+        if domain is None or domain not in self.domains:
+            return
+        for intent in self.domains[domain].determine_intent(
+                utterance=utterance, num_results=num_results,
+                include_tags=include_tags, context_manager=context_manager):
+            yield intent

--- a/ovos_adapt/opm.py
+++ b/ovos_adapt/opm.py
@@ -30,7 +30,7 @@ from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_workshop.intents import open_intent_envelope
 
-from ovos_adapt.engine import IntentDeterminationEngine
+from ovos_adapt.engine import IntentDeterminationEngine, DomainIntentDeterminationEngine
 
 
 def _entity_skill_id(skill_id):
@@ -396,3 +396,215 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
         """
         self.bus.emit(message.reply("intent.service.adapt.vocab.manifest",
                                     {"vocab": self.registered_vocab}))
+
+
+def _domain_from_intent_name(intent_name: str) -> str:
+    """Extract skill_id domain from an intent label.
+
+    Intent labels follow the ``skill_id:intent_name`` convention. If no
+    ``:`` is present the full label is used as the domain.
+    """
+    if not intent_name:
+        return ""
+    return intent_name.split(":", 1)[0] if ":" in intent_name else intent_name
+
+
+class DomainAdaptPipeline(AdaptPipeline):
+    """Adapt pipeline backed by ``DomainIntentDeterminationEngine``.
+
+    Unlike :class:`AdaptPipeline`, this variant maintains a dedicated
+    per-skill ``IntentDeterminationEngine`` (a "domain"). At match time,
+    every domain is scored in parallel and a global ``nlargest`` selects
+    the winner — no top-level router is involved.
+
+    Intent registrations are routed to the right domain based on the
+    ``skill_id`` prefix of the intent label (``skill_id:intent_name``).
+    """
+
+    def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
+                 config: Optional[Dict] = None):
+        core_config = Configuration()
+        # Use dedicated config section so users can tune this pipeline
+        # independently from the flat AdaptPipeline.
+        config = config or core_config.get("intents", {}).get(
+            "ovos_adapt_domain_pipeline", {})
+        # Skip AdaptPipeline.__init__ to avoid building a flat engine; call
+        # the grandparent initializer directly.
+        ConfidenceMatcherPipeline.__init__(self, bus, config)
+        self.lang = standardize_lang_tag(core_config.get("lang", "en-US"))
+        langs = core_config.get('secondary_langs') or []
+        if self.lang not in langs:
+            langs.append(self.lang)
+        langs = [standardize_lang_tag(l) for l in langs]
+        self.engines = {lang: DomainIntentDeterminationEngine()
+                        for lang in langs}
+
+        self.lock = Lock()
+        self.registered_vocab = []
+        self.max_words = 50
+
+        self.conf_high = self.config.get("conf_high") or 0.65
+        self.conf_med = self.config.get("conf_med") or 0.45
+        self.conf_low = self.config.get("conf_low") or 0.25
+
+        # Maps lang -> entity_type_prefix -> domain (skill_id). Allows the
+        # vocab/regex registration handlers, which only see entity_type, to
+        # route to the correct domain.
+        self._entity_domain_index: Dict[str, Dict[str, str]] = {
+            lang: {} for lang in langs
+        }
+
+        self.bus.on('register_vocab', self.handle_register_vocab)
+        self.bus.on('register_intent', self.handle_register_intent)
+        self.bus.on('detach_intent', self.handle_detach_intent)
+        self.bus.on('detach_skill', self.handle_detach_skill)
+
+        self.bus.on('intent.service.adapt.get', self.handle_get_adapt)
+        self.bus.on('intent.service.adapt.manifest.get', self.handle_adapt_manifest)
+        self.bus.on('intent.service.adapt.vocab.manifest.get', self.handle_vocab_manifest)
+
+    def _resolve_entity_domain(self, lang: str, entity_type: str) -> str:
+        """Best-effort lookup of the domain that owns an entity_type.
+
+        Vocab/regex registrations don't carry ``skill_id`` directly; we map
+        them by entity_type prefix populated when intents are registered.
+        Falls back to the entity_type itself if no match is found.
+        """
+        index = self._entity_domain_index.get(lang, {})
+        # exact match first
+        if entity_type in index:
+            return index[entity_type]
+        # longest-prefix match (entity_type often == "<skill_id_norm><Name>")
+        best = ""
+        for prefix, domain in index.items():
+            if entity_type.startswith(prefix) and len(prefix) > len(best):
+                best = prefix
+        if best:
+            return index[best]
+        return entity_type
+
+    @lru_cache(maxsize=3)
+    def match_intent(self, utterances: Iterable[str],
+                     lang: Optional[str] = None,
+                     message: Optional[str] = None):
+        """Run all per-domain engines in parallel, take the global argmax.
+
+        ``DomainIntentDeterminationEngine.determine_intent`` does not
+        propagate ``include_tags``/``context_manager`` to its sub-engines,
+        so we iterate sub-engines manually to preserve adapt's contextual
+        scoring behaviour.
+        """
+        if message:
+            message = Message.deserialize(message)
+        sess = SessionManager.get(message)
+
+        utterances = flatten_list(utterances)
+        utterances = [u for u in utterances if len(u.split()) < self.max_words]
+        if not utterances:
+            LOG.error(f"utterance exceeds max size of {self.max_words} words, skipping adapt match")
+            return None
+
+        lang = self._get_closest_lang(lang)
+        if lang is None:
+            return None
+
+        best_intent = {}
+
+        def take_best(intent, utt):
+            nonlocal best_intent
+            best = best_intent.get('confidence', 0.0) if best_intent else 0.0
+            conf = intent.get('confidence', 0.0)
+            skill = intent['intent_type'].split(":")[0]
+            if best < conf and intent["intent_type"] not in sess.blacklisted_intents \
+                    and skill not in sess.blacklisted_skills:
+                best_intent = intent
+                best_intent['utterance'] = utt
+
+        engine = self.engines[lang]
+        for utt in utterances:
+            try:
+                candidates = []
+                for sub in engine.domains.values():
+                    for it in sub.determine_intent(
+                            utterance=utt, num_results=1,
+                            include_tags=True,
+                            context_manager=sess.context):
+                        candidates.append(it)
+                if candidates:
+                    utt_best = max(candidates,
+                                   key=lambda x: x.get('confidence', 0.0))
+                    take_best(utt_best, utt)
+            except Exception as err:
+                LOG.exception(err)
+
+        if best_intent:
+            ents = [tag['entities'][0] for tag in best_intent['__tags__']
+                    if 'entities' in tag]
+            sess.context.update_context(ents)
+            skill_id = best_intent['intent_type'].split(":")[0]
+            return IntentHandlerMatch(
+                match_type=best_intent['intent_type'],
+                match_data=best_intent, skill_id=skill_id,
+                utterance=best_intent['utterance']
+            )
+        return None
+
+    def register_intent(self, intent):
+        """Register a new intent with the per-domain engine."""
+        domain = _domain_from_intent_name(intent.name)
+        # Track entity_type prefix -> domain so vocab registrations can
+        # be routed to the same engine.
+        norm = _entity_skill_id(domain + ".")  # mimic skill_id formatting
+        for lang in self.engines:
+            with self.lock:
+                self.engines[lang].register_intent_parser(intent, domain=domain)
+                self._entity_domain_index[lang][norm] = domain
+
+    def register_vocabulary(self, entity_value: str, entity_type: str,
+                            alias_of: str, regex_str: str, lang: str):
+        """Register skill vocabulary, routed by entity_type to a domain."""
+        lang = standardize_lang_tag(lang)
+        if lang in self.engines:
+            with self.lock:
+                domain = self._resolve_entity_domain(
+                    lang, entity_type if not regex_str else regex_str)
+                if regex_str:
+                    self.engines[lang].register_regex_entity(
+                        regex_str, domain=domain)
+                else:
+                    self.engines[lang].register_entity(
+                        entity_value, entity_type, alias_of=alias_of,
+                        domain=domain)
+
+    def detach_skill(self, skill_id):
+        """Drop the whole domain for a skill."""
+        with self.lock:
+            for lang in self.engines:
+                if skill_id in self.engines[lang].domains:
+                    del self.engines[lang].domains[skill_id]
+                # also drop any entity prefix index entries pointing here
+                idx = self._entity_domain_index.get(lang, {})
+                for prefix in [p for p, d in idx.items() if d == skill_id]:
+                    idx.pop(prefix, None)
+
+    def detach_intent(self, intent_name):
+        """Detach a single intent from its owning domain."""
+        domain = _domain_from_intent_name(intent_name)
+        for lang in self.engines:
+            engine = self.engines[lang]
+            if domain in engine.domains:
+                sub = engine.domains[domain]
+                sub.intent_parsers = [p for p in sub.intent_parsers
+                                      if p.name != intent_name]
+
+    def shutdown(self):
+        for lang in self.engines:
+            self.engines[lang].domains = {}
+
+    @property
+    def registered_intents(self):
+        lang = get_message_lang()
+        out = []
+        for sub in self.engines[lang].domains.values():
+            out.extend(parser.__dict__ for parser in sub.intent_parsers)
+        return out

--- a/ovos_adapt/opm.py
+++ b/ovos_adapt/opm.py
@@ -30,7 +30,9 @@ from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_workshop.intents import open_intent_envelope
 
-from ovos_adapt.engine import IntentDeterminationEngine, DomainIntentDeterminationEngine
+from ovos_adapt.engine import (IntentDeterminationEngine,
+                                DomainIntentDeterminationEngine,
+                                HierarchicalIntentDeterminationEngine)
 
 
 def _entity_skill_id(skill_id):
@@ -421,13 +423,18 @@ class DomainAdaptPipeline(AdaptPipeline):
     ``skill_id`` prefix of the intent label (``skill_id:intent_name``).
     """
 
+    #: per-domain engine class; overridden by HierarchicalAdaptPipeline.
+    _engine_class = DomainIntentDeterminationEngine
+    #: config section under ``intents``; overridden by subclasses.
+    _config_key = "ovos_adapt_domain_pipeline"
+
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
                  config: Optional[Dict] = None):
         core_config = Configuration()
         # Use dedicated config section so users can tune this pipeline
         # independently from the flat AdaptPipeline.
         config = config or core_config.get("intents", {}).get(
-            "ovos_adapt_domain_pipeline", {})
+            self._config_key, {})
         # Skip AdaptPipeline.__init__ to avoid building a flat engine; call
         # the grandparent initializer directly.
         ConfidenceMatcherPipeline.__init__(self, bus, config)
@@ -436,7 +443,7 @@ class DomainAdaptPipeline(AdaptPipeline):
         if self.lang not in langs:
             langs.append(self.lang)
         langs = [standardize_lang_tag(l) for l in langs]
-        self.engines = {lang: DomainIntentDeterminationEngine()
+        self.engines = {lang: self._engine_class()
                         for lang in langs}
 
         self.lock = Lock()
@@ -483,6 +490,20 @@ class DomainAdaptPipeline(AdaptPipeline):
             return index[best]
         return entity_type
 
+    def _gather_candidates(self, engine, utt, sess):
+        """Collect intent candidates for an utterance.
+
+        Scores every domain sub-engine in parallel. Overridden by
+        :class:`HierarchicalAdaptPipeline` to score a single routed domain.
+        """
+        candidates = []
+        for sub in engine.domains.values():
+            for it in sub.determine_intent(
+                    utterance=utt, num_results=1, include_tags=True,
+                    context_manager=sess.context):
+                candidates.append(it)
+        return candidates
+
     @lru_cache(maxsize=3)
     def match_intent(self, utterances: Iterable[str],
                      lang: Optional[str] = None,
@@ -523,13 +544,7 @@ class DomainAdaptPipeline(AdaptPipeline):
         engine = self.engines[lang]
         for utt in utterances:
             try:
-                candidates = []
-                for sub in engine.domains.values():
-                    for it in sub.determine_intent(
-                            utterance=utt, num_results=1,
-                            include_tags=True,
-                            context_manager=sess.context):
-                        candidates.append(it)
+                candidates = self._gather_candidates(engine, utt, sess)
                 if candidates:
                     utt_best = max(candidates,
                                    key=lambda x: x.get('confidence', 0.0))
@@ -608,3 +623,23 @@ class DomainAdaptPipeline(AdaptPipeline):
         for sub in self.engines[lang].domains.values():
             out.extend(parser.__dict__ for parser in sub.intent_parsers)
         return out
+
+
+class HierarchicalAdaptPipeline(DomainAdaptPipeline):
+    """Adapt pipeline backed by ``HierarchicalIntentDeterminationEngine``.
+
+    Shares the per-skill domain model and registration routing of
+    :class:`DomainAdaptPipeline`. Unlike that pipeline, which scores every
+    domain in parallel, this variant classifies the domain first and
+    evaluates only that domain's sub-engine. A misclassified domain cannot
+    be recovered.
+    """
+
+    _engine_class = HierarchicalIntentDeterminationEngine
+    _config_key = "ovos_adapt_hierarchical_pipeline"
+
+    def _gather_candidates(self, engine, utt, sess):
+        """Collect intent candidates from the single routed domain."""
+        return list(engine.determine_intent(
+            utterance=utt, num_results=1, include_tags=True,
+            context_manager=sess.context))

--- a/ovos_adapt/opm.py
+++ b/ovos_adapt/opm.py
@@ -496,8 +496,10 @@ class DomainAdaptPipeline(AdaptPipeline):
         Scores every domain sub-engine in parallel. Overridden by
         :class:`HierarchicalAdaptPipeline` to score a single routed domain.
         """
+        with self.lock:
+            sub_engines = list(engine.domains.values())
         candidates = []
-        for sub in engine.domains.values():
+        for sub in sub_engines:
             for it in sub.determine_intent(
                     utterance=utt, num_results=1, include_tags=True,
                     context_manager=sess.context):
@@ -581,8 +583,7 @@ class DomainAdaptPipeline(AdaptPipeline):
         lang = standardize_lang_tag(lang)
         if lang in self.engines:
             with self.lock:
-                domain = self._resolve_entity_domain(
-                    lang, entity_type if not regex_str else regex_str)
+                domain = self._resolve_entity_domain(lang, entity_type)
                 if regex_str:
                     self.engines[lang].register_regex_entity(
                         regex_str, domain=domain)
@@ -605,16 +606,18 @@ class DomainAdaptPipeline(AdaptPipeline):
     def detach_intent(self, intent_name):
         """Detach a single intent from its owning domain."""
         domain = _domain_from_intent_name(intent_name)
-        for lang in self.engines:
-            engine = self.engines[lang]
-            if domain in engine.domains:
-                sub = engine.domains[domain]
-                sub.intent_parsers = [p for p in sub.intent_parsers
-                                      if p.name != intent_name]
+        with self.lock:
+            for lang in self.engines:
+                engine = self.engines[lang]
+                if domain in engine.domains:
+                    sub = engine.domains[domain]
+                    sub.intent_parsers = [p for p in sub.intent_parsers
+                                          if p.name != intent_name]
 
     def shutdown(self):
-        for lang in self.engines:
-            self.engines[lang].domains = {}
+        with self.lock:
+            for lang in self.engines:
+                self.engines[lang].domains = {}
 
     @property
     def registered_intents(self):
@@ -640,6 +643,7 @@ class HierarchicalAdaptPipeline(DomainAdaptPipeline):
 
     def _gather_candidates(self, engine, utt, sess):
         """Collect intent candidates from the single routed domain."""
-        return list(engine.determine_intent(
-            utterance=utt, num_results=1, include_tags=True,
-            context_manager=sess.context))
+        with self.lock:
+            return list(engine.determine_intent(
+                utterance=utt, num_results=1, include_tags=True,
+                context_manager=sess.context))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ Homepage = "https://github.com/OpenVoiceOS/ovos-adapt-pipeline-plugin"
 [project.entry-points."opm.pipeline"]
 "ovos-adapt-pipeline-plugin" = "ovos_adapt.opm:AdaptPipeline"
 "ovos-adapt-domain-pipeline-plugin" = "ovos_adapt.opm:DomainAdaptPipeline"
+"ovos-adapt-hierarchical-pipeline-plugin" = "ovos_adapt.opm:HierarchicalAdaptPipeline"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Homepage = "https://github.com/OpenVoiceOS/ovos-adapt-pipeline-plugin"
 
 [project.entry-points."opm.pipeline"]
 "ovos-adapt-pipeline-plugin" = "ovos_adapt.opm:AdaptPipeline"
+"ovos-adapt-domain-pipeline-plugin" = "ovos_adapt.opm:DomainAdaptPipeline"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/test/test_domain_pipeline.py
+++ b/test/test_domain_pipeline.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Open Voice OS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for the per-domain Adapt pipeline.
+
+These tests ensure that ``DomainAdaptPipeline`` registers each skill's
+intents into a dedicated sub-engine (a "domain") and that
+``match_intent`` picks the correct skill regardless of how many domains
+are registered.
+"""
+from unittest import TestCase, mock
+
+from ovos_bus_client.message import Message
+from ovos_workshop.intents import IntentBuilder
+
+from ovos_adapt.engine import DomainIntentDeterminationEngine
+from ovos_adapt.opm import DomainAdaptPipeline
+
+
+def _vocab_msg(keyword, value):
+    return Message('register_vocab',
+                   {'entity_value': value, 'entity_type': keyword})
+
+
+class TestDomainAdaptPipeline(TestCase):
+
+    def setUp(self):
+        self.pipeline = DomainAdaptPipeline(mock.Mock())
+
+        # Skill A: weather
+        intent_a = (IntentBuilder('weather.skill:WeatherIntent')
+                    .require('weather_skillWeatherKeyword'))
+        # Skill B: music
+        intent_b = (IntentBuilder('music.skill:PlayIntent')
+                    .require('music_skillPlayKeyword'))
+
+        # Register intents first so the entity_type prefix index is
+        # populated before vocab arrives.
+        self.pipeline.handle_register_intent(
+            Message('register_intent', intent_a.__dict__))
+        self.pipeline.handle_register_intent(
+            Message('register_intent', intent_b.__dict__))
+
+        self.pipeline.handle_register_vocab(
+            _vocab_msg('weather_skillWeatherKeyword', 'weather'))
+        self.pipeline.handle_register_vocab(
+            _vocab_msg('music_skillPlayKeyword', 'play'))
+
+    def test_engine_is_domain_engine(self):
+        for engine in self.pipeline.engines.values():
+            self.assertIsInstance(engine, DomainIntentDeterminationEngine)
+
+    def test_two_domains_registered(self):
+        lang = self.pipeline.lang
+        engine = self.pipeline.engines[lang]
+        self.assertIn('weather.skill', engine.domains)
+        self.assertIn('music.skill', engine.domains)
+        # Each domain only owns its own intent parser.
+        weather_names = [p.name for p in
+                         engine.domains['weather.skill'].intent_parsers]
+        music_names = [p.name for p in
+                       engine.domains['music.skill'].intent_parsers]
+        self.assertEqual(weather_names, ['weather.skill:WeatherIntent'])
+        self.assertEqual(music_names, ['music.skill:PlayIntent'])
+
+    def test_match_routes_to_weather_domain(self):
+        match = self.pipeline.match_intent(('weather',), self.pipeline.lang, None)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.match_type, 'weather.skill:WeatherIntent')
+        self.assertEqual(match.skill_id, 'weather.skill')
+
+    def test_match_routes_to_music_domain(self):
+        match = self.pipeline.match_intent(('play',), self.pipeline.lang, None)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.match_type, 'music.skill:PlayIntent')
+        self.assertEqual(match.skill_id, 'music.skill')
+
+    def test_detach_skill_drops_domain(self):
+        self.pipeline.detach_skill('weather.skill')
+        engine = self.pipeline.engines[self.pipeline.lang]
+        self.assertNotIn('weather.skill', engine.domains)
+        # The other domain is untouched.
+        self.assertIn('music.skill', engine.domains)
+
+    def test_detach_intent_removes_only_that_intent(self):
+        self.pipeline.detach_intent('weather.skill:WeatherIntent')
+        engine = self.pipeline.engines[self.pipeline.lang]
+        names = [p.name for p in
+                 engine.domains['weather.skill'].intent_parsers]
+        self.assertEqual(names, [])


### PR DESCRIPTION
## Summary

Exposes adapt's domain-based intent matching as OPM pipeline plugins, adds a
two-stage hierarchical variant, and ships a comparison harness for the three
engine topologies.

### Engine topologies — now consistent across the package

| | engine (`engine.py`) | pipeline (`opm.py`) | entry point |
|---|---|---|---|
| flat | `IntentDeterminationEngine` | `AdaptPipeline` | `ovos-adapt-pipeline-plugin` |
| domain | `DomainIntentDeterminationEngine` | `DomainAdaptPipeline` | `ovos-adapt-domain-pipeline-plugin` |
| hierarchical | `HierarchicalIntentDeterminationEngine` *(new)* | `HierarchicalAdaptPipeline` *(new)* | `ovos-adapt-hierarchical-pipeline-plugin` *(new)* |

- **`DomainAdaptPipeline`** — surfaces the existing `DomainIntentDeterminationEngine`
  (parallel scoring across per-skill domains, global argmax). Routes intent/vocab
  registration to the right sub-engine by `skill_id`; config from
  `intents.ovos_adapt_domain_pipeline`. Refactored to expose `_engine_class` /
  `_config_key` class attributes and a `_gather_candidates` hook.
- **`HierarchicalIntentDeterminationEngine`** — subclass of
  `DomainIntentDeterminationEngine` with the same registration API. Its
  `determine_intent` runs a stage-1 keyword-coverage classifier (`classify_domain`)
  to pick one domain, then resolves only within it.
- **`HierarchicalAdaptPipeline`** — subclass of `DomainAdaptPipeline`; overrides
  only candidate gathering to route through the one classified domain. Config
  from `intents.ovos_adapt_hierarchical_pipeline`.

### Benchmark / engine-comparison reference

- `benchmark/compare.py` runs all three topologies on a shared keyword dataset
  and reports accuracy, precision/recall, false positives, a flat-vs-domain
  head-to-head, stage-1 routing accuracy, and latency.
- `benchmark/dataset.py` is a small **hand-tuned reference corpus**, not a
  representative benchmark — it is deliberately built to surface where the
  topologies diverge, and its accuracy numbers are an artifact of how the
  discriminating sections are mixed. See `docs/benchmark.md` ("Reading the
  numbers"), which explains the `confidence = intent_conf / len(clique_tags) ×
  clique_conf` dilution mechanism and how the dataset can be skewed to favour
  any engine.

## Test plan

- [x] Local: 102/102 tests pass (`test/`)
- [x] `benchmark/compare.py` runs clean
- [x] CodeRabbit review addressed (domain-structure locking, regex routing key,
  intent→domain validation, stage-1 zero-division guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)