### PR TITLE
docs: zero-to-hero documentation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ The Adapt Intent Parser is a flexible and extensible intent definition and deter
 
 This repository contains a OVOS pipeline plugin and bundles a fork of the original [adapt-parser](https://github.com/MycroftAI/adapt) from the defunct MycroftAI
 
+Documentation
+=============
+A zero-to-hero guide lives in [`docs/`](docs/index.md):
+
+- [Concepts](docs/concepts.md) — entities, intents, cliques, and confidence
+- [Quickstart](docs/quickstart.md) — install, enable, match your first utterance
+- [Writing intents](docs/writing-intents.md) — the `IntentBuilder` API with examples
+- [Configuration](docs/configuration.md) — confidence tiers and every config key
+- [Bus protocol](docs/bus-protocol.md) — the messagebus API skills register over
+- [Internals](docs/internals.md) — tagging, clique expansion, the confidence math
+
 Examples
 ========
 Executable examples can be found in the [examples folder](https://github.com/MycroftAI/adapt/tree/master/examples).

--- a/docs/bus-protocol.md
+++ b/docs/bus-protocol.md
@@ -1,0 +1,87 @@
+# Bus protocol
+
+In a full OVOS install the plugin is driven entirely over the messagebus.
+Skills emit registration messages; the plugin matches utterances and emits
+results. This page documents that contract — useful when writing a skill
+framework, debugging, or integrating a non-standard skill.
+
+## Registration messages (skill → plugin)
+
+The plugin listens for four messages:
+
+### `register_vocab`
+
+Registers one entity. `message.data`:
+
+| Field | Meaning |
+|---|---|
+| `entity_value` | the surface form, e.g. `"Tokyo"` |
+| `entity_type` | the type, e.g. `"Location"` |
+| `regex` | a regex string (instead of `entity_value`/`entity_type`) |
+| `alias_of` | optional canonical form this value resolves to |
+| `lang` | language tag; routed to that language's engine |
+
+A plain keyword sends `entity_value` + `entity_type`. A regex entity sends
+`regex` (with a named group). One message registers one entity, so a skill
+emits many.
+
+### `register_intent`
+
+Registers a built intent. The data is an intent envelope produced by
+`IntentBuilder(...).build()` and serialised by `ovos_workshop.intents`. The
+plugin reconstructs the parser and adds it to the engine.
+
+### `detach_intent`
+
+Removes a single intent. `message.data['intent_name']` — the intent's name.
+
+### `detach_skill`
+
+Removes every intent and vocab item belonging to a skill.
+`message.data['skill_id']` — all intents whose name starts with that prefix are
+dropped. Emitted when a skill unloads.
+
+## Query messages
+
+### `intent.service.adapt.get`
+
+Ask the plugin to match an utterance directly (debugging / introspection). The
+plugin replies with the best intent or a null match.
+
+### `intent.service.adapt.manifest.get`
+
+Replies with the list of registered intents.
+
+### `intent.service.adapt.vocab.manifest.get`
+
+Replies with the list of registered vocabulary.
+
+## Matching flow
+
+The plugin does not match on `register_*`. Matching is driven by the OVOS
+intent service, which calls the tier methods (`match_high`, `match_medium`,
+`match_low`) as it walks the configured pipeline. Each call:
+
+1. takes the incoming utterance(s) for the session language,
+2. skips anything longer than `max_words`,
+3. runs the engine's `determine_intent`,
+4. returns the best result **if** its confidence clears the tier threshold,
+5. on a returned match, feeds the matched entities back into the session
+   context so follow-up utterances can use them.
+
+## Result shape
+
+A match is an `IntentHandlerMatch` carrying:
+
+- `match_type` — the intent name (`skill_id:intent_name`)
+- `match_data` — the parsed intent dict: `confidence`, every matched slot keyed
+  by entity type, and `__tags__` (the raw tags, used for context)
+- `skill_id` — the owning skill, taken from the intent-name prefix
+- `utterance` — the utterance that matched
+
+## Sessions and context
+
+Each match updates the `Session` context with the entities it consumed.
+A later utterance can then satisfy a `require`d slot from context instead of
+from its own words — this is how follow-up commands ("...and the bedroom one
+too") resolve. Context is per-session; see [Internals](internals.md).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,107 @@
+# Concepts
+
+This page explains *how* Adapt decides which intent an utterance belongs to.
+No prior knowledge is assumed.
+
+## The problem
+
+A user says *"what's the weather in Tokyo"*. The assistant must decide which
+registered action — which **intent** — that sentence is asking for, and pull
+out the useful values (`Tokyo`). Adapt solves this with keyword matching plus a
+few combination rules.
+
+## Entities
+
+An **entity** is a named value. You register entities by listing their possible
+surface forms and giving each a **type**:
+
+```text
+type "WeatherKeyword"  ->  "weather", "forecast"
+type "Location"        ->  "Seattle", "San Francisco", "Tokyo"
+```
+
+When Adapt sees one of those words in an utterance, it **tags** it: the word
+`Tokyo` becomes a tag of type `Location`. Tagging is exact — Adapt only finds
+words you registered. There is no fuzzy matching and no generalisation.
+
+Internally every registered surface form is stored in a **Trie** (a prefix
+tree), so tagging an utterance is fast even with thousands of entities.
+
+## Intents
+
+An **intent** is an action, defined as a set of requirements over entity
+*types*. You build one with `IntentBuilder`:
+
+```python
+from ovos_adapt.intent import IntentBuilder
+
+weather = IntentBuilder("WeatherIntent") \
+    .require("WeatherKeyword") \
+    .require("Location") \
+    .optionally("WeatherType") \
+    .build()
+```
+
+This says: the `WeatherIntent` fires when the utterance contains **both** a
+`WeatherKeyword` tag and a `Location` tag; a `WeatherType` tag is used if
+present but is not required.
+
+The four rules an intent can use:
+
+| Rule | Meaning |
+|---|---|
+| `require(type)` | the intent only matches if a tag of this type is present |
+| `optionally(type)` | used if present, ignored if absent — adds confidence |
+| `one_of([types])` | at least one of these types must be present |
+| `exclude(type)` | the intent is rejected if a tag of this type is present |
+
+An intent that misses any `require` (or `one_of`, or hits an `exclude`) scores
+**zero** and does not fire.
+
+## Cliques: handling overlap
+
+A word can be tagged as more than one type, and two tags can cover overlapping
+parts of the utterance. Adapt cannot use two overlapping tags in the same
+answer, so it expands the tag list into **cliques** — maximal sets of tags that
+do *not* overlap each other. Each clique is one self-consistent reading of the
+utterance. Every intent is then validated against each clique.
+
+## Confidence
+
+OVOS pipelines work in confidence scores between 0 and 1. Adapt computes an
+intent's confidence from three things:
+
+```text
+confidence = intent_weight / total_tags  x  clique_coverage
+```
+
+- **intent_weight** — how many of the clique's tags this intent actually used
+  (its required + optional slots). More matched slots → higher weight.
+- **total_tags** — how many tags the clique has in total. Tags the intent did
+  *not* use still divide the score, so an utterance crowded with unrelated
+  keywords **dilutes** every intent.
+- **clique_coverage** — how much of the utterance, character for character, the
+  clique's tags cover. Longer matched keywords cover more and score higher.
+
+The practical consequences:
+
+- An intent that explains *more* of the utterance scores higher.
+- A short keyword buried in a long sentence scores low — most of the sentence
+  is uncovered.
+- Stray keywords from other intents lower everyone's score.
+
+## Confidence tiers
+
+OVOS runs pipeline plugins in three passes — `match_high`, `match_medium`,
+`match_low`. Adapt exposes the same matching at three thresholds
+(`conf_high` 0.65, `conf_med` 0.45, `conf_low` 0.25). A match is only returned
+in a pass if its confidence clears that pass's threshold, so a confident Adapt
+intent is matched before lower-confidence pipeline stages get a turn. See
+[Configuration](configuration.md).
+
+## Next
+
+- [Quickstart](quickstart.md) — see all of this run end to end.
+- [Writing intents](writing-intents.md) — the full `IntentBuilder` API with
+  worked examples.
+- [Internals](internals.md) — the exact tagging, clique, and confidence maths.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,77 @@
+# Configuration
+
+## Entry point
+
+The plugin is published under the OPM `opm.pipeline` entry point:
+
+```toml
+[project.entry-points."opm.pipeline"]
+"ovos-adapt-pipeline-plugin" = "ovos_adapt.opm:AdaptPipeline"
+```
+
+OVOS discovers it by that id — `ovos-adapt-pipeline-plugin`.
+
+## Enabling it in the pipeline
+
+`mycroft.conf`, under `intents.pipeline`, lists the matcher stages in priority
+order. Each Adapt stage is referenced by id plus a confidence-tier suffix:
+
+```json
+{
+  "intents": {
+    "pipeline": [
+      "ovos-adapt-pipeline-plugin-high",
+      "ovos-padatious-pipeline-plugin-high",
+      "ovos-adapt-pipeline-plugin-medium",
+      "ovos-adapt-pipeline-plugin-low"
+    ]
+  }
+}
+```
+
+A stage earlier in the list wins ties. A common layout runs every matcher's
+**high** tier first, then medium, then low, so a confident match from any
+matcher beats a shaky match from the one listed first.
+
+## Confidence tiers
+
+The plugin exposes three matchers, one per tier. Each returns a match only when
+its confidence clears the tier threshold:
+
+| Tier | Method | Default threshold | Config key |
+|---|---|---|---|
+| high | `match_high` | 0.65 | `conf_high` |
+| medium | `match_medium` | 0.45 | `conf_med` |
+| low | `match_low` | 0.25 | `conf_low` |
+
+The same utterance is scored once; the tier only decides which threshold the
+score must clear. Lower a threshold to let weaker matches through that tier;
+raise it to demand a stronger match.
+
+## Settings
+
+| Key | Default | Effect |
+|---|---|---|
+| `conf_high` | `0.65` | minimum confidence for a `match_high` result |
+| `conf_med` | `0.45` | minimum confidence for a `match_medium` result |
+| `conf_low` | `0.25` | minimum confidence for a `match_low` result |
+| `max_words` | `50` | utterances longer than this are skipped unmatched |
+
+Keep the thresholds ordered `conf_low <= conf_med <= conf_high`; an inverted
+order makes a tier unreachable.
+
+`max_words` is a guard: very long utterances are rarely commands and are
+expensive to expand into cliques, so they are dropped before matching.
+
+## Tuning
+
+- **Too many false matches** (the assistant acts on off-hand remarks) — raise
+  `conf_high`, or give the over-eager intents more `require`d slots so they
+  demand a fuller command. See [Concepts](concepts.md).
+- **Real commands missed** — check the utterance actually contains a registered
+  surface form for every required slot; confidence cannot rescue a missing
+  `require`. Lowering `conf_low` only helps if the intent scored *something*.
+- **Confidence feels low on correct matches** — short keywords in long
+  sentences score low by design (little of the utterance is covered). Register
+  longer, more specific surface forms, or add `optionally` slots that cover
+  more words.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+# ovos-adapt-pipeline-plugin documentation
+
+`ovos-adapt-pipeline-plugin` is an OVOS intent pipeline plugin. It matches a
+spoken utterance to a registered intent using **keyword and rule matching** —
+no training step, no model files, no GPU. It bundles a maintained fork of the
+original MycroftAI [adapt](https://github.com/MycroftAI/adapt) parser.
+
+This documentation goes from zero to hero. If you have never written an intent,
+start at [Concepts](concepts.md). If you just want it running, jump to the
+[Quickstart](quickstart.md).
+
+## Reading order
+
+**New to intent parsing** — read in order:
+
+1. [Concepts](concepts.md) — what an entity, an intent, and a confidence score are
+2. [Quickstart](quickstart.md) — install, enable, and match your first utterance
+3. [Writing intents](writing-intents.md) — register vocabulary and build intents
+4. [Configuration](configuration.md) — confidence tiers and every config key
+
+**Building on or extending the plugin:**
+
+5. [Bus protocol](bus-protocol.md) — the messagebus API skills use to register
+6. [Internals](internals.md) — the tagger, clique expansion, the confidence math
+
+## At a glance
+
+```text
+utterance
+  -> tokenize into words
+  -> tag every entity found in the vocabulary Trie
+  -> expand the tags into non-overlapping entity sets ("cliques")
+  -> validate each intent's required / optional slots against a clique
+  -> confidence = matched-slot weight / total tags  x  clique coverage
+  -> the highest-confidence intent wins
+```
+
+## Where Adapt fits
+
+OVOS runs several intent matchers in a pipeline. Adapt is the **keyword/rule**
+matcher:
+
+- **Adapt** — you list the words that trigger each intent. Deterministic,
+  registers instantly, no training. Best for command-style intents
+  (*"turn off the kitchen lights"*).
+- **Padatious / Padacioso** — train a small model on example sentences.
+  Generalises to phrasings you did not write, at the cost of a training step.
+- **Common Query / fallback** — catch-all stages for everything else.
+
+A skill can register intents with whichever matcher suits each intent. Adapt is
+the right choice when the trigger words are known and finite.
+
+## Requirements
+
+- Python 3.10+
+- `ovos-plugin-manager`, `ovos-bus-client`, `ovos-config`, `ovos-utils`,
+  `ovos-workshop`
+
+The adapt parser itself (`ovos_adapt.engine`, `ovos_adapt.intent`) has no
+runtime dependency beyond the standard library and can be used standalone.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,126 @@
+# Internals
+
+This page traces what happens inside `determine_intent`, derives the confidence
+formula from the source, and covers the domain engine and context. It is for
+developers extending the plugin or debugging surprising scores.
+
+## The matching pipeline
+
+`IntentDeterminationEngine.determine_intent(utterance, num_results=1)` runs four
+stages:
+
+```text
+utterance
+  1. tag      EntityTagger      -> every entity occurrence in the utterance
+  2. expand   BronKerboschExpander -> non-overlapping tag sets (cliques)
+  3. validate Intent.validate_with_tags -> best intent per clique
+  4. rank     -> highest-confidence intent overall
+```
+
+### 1. Tagging
+
+The engine keeps every registered surface form in a **Trie** (`ovos_adapt`'s
+`trie.py`). The `EntityTagger` walks the tokenised utterance against the Trie
+and against any registered regex entities, emitting a tag for every match —
+position, matched text, entity type, and a per-entity confidence. One word can
+produce several tags if it was registered under several types.
+
+### 2. Clique expansion
+
+Tags can overlap in the utterance, and a valid answer cannot use two
+overlapping tags at once. The `BronKerboschExpander` treats "does not overlap"
+as a graph edge and finds **maximal cliques** — each clique is one complete,
+self-consistent set of non-overlapping tags. Cliques are scored and yielded
+best-first; `num_results` (`N`) caps how many are produced.
+
+The clique score (`score_clique` in `parser.py`) is:
+
+```text
+clique_score = Σ  entity_confidence × len(match) / (len(utterance) + 1)
+```
+
+summed over the clique's tags — i.e. how much of the utterance the clique
+covers, weighted by each tag's confidence.
+
+### 3. Validation
+
+For each clique, `__best_intent` runs every registered intent's
+`validate_with_tags(tags, clique_confidence)` and keeps the highest scorer.
+
+### 4. Ranking
+
+`determine_intent` yields one best-intent per clique. Callers take the global
+maximum by `confidence`.
+
+## The confidence formula
+
+`Intent.validate_with_tags` (in `ovos_workshop.intents`) computes:
+
+```text
+intent_confidence = Σ  tag_confidence   over the intent's used slots
+                    (required + one_of + optional tags it matched)
+
+total_confidence  = intent_confidence / len(tags)  ×  clique_confidence
+```
+
+where `len(tags)` is **every** tag in the clique — including tags this intent
+did not use. Three forces, then:
+
+- **`intent_confidence`** rises with each required/optional slot the intent
+  fills. More matched slots → higher score.
+- **`len(tags)`** is a divisor over *all* clique tags. Tags belonging to other
+  intents still divide the score — unrelated keywords in the utterance
+  **dilute** every intent equally.
+- **`clique_confidence`** is the coverage term — longer matched keywords, and
+  more of the utterance explained, score higher.
+
+A missing `require`d slot, an unmet `one_of`, or a hit `exclude` short-circuits
+to `confidence = 0.0`.
+
+### Worked example
+
+Utterance *"turn off the kitchen lights"*, intent `lights:off` requiring
+`OffKeyword` + `LightKeyword`, optional `RoomKeyword`. The best clique tags
+`turn off` (Off), `kitchen` (Room), `lights` (Light) — 3 tags, all used by the
+intent. `intent_confidence` sums all three; `len(tags)` is 3; `clique_confidence`
+reflects that those three tags cover most of the sentence. The score is high.
+
+Add an unrelated registered word — say `play` — and a fourth tag appears.
+`lights:off` still uses 3 tags but `len(tags)` is now 4, so its score drops even
+though the command is unchanged. This dilution is the main reason scores differ
+between engine topologies (see below).
+
+## DomainIntentDeterminationEngine
+
+`DomainIntentDeterminationEngine` groups intents into **domains**, each backed
+by its own `IntentDeterminationEngine` — its own Trie, tagger, and parser set.
+Registration takes a `domain=` argument; `determine_intent` scores every domain
+and the caller takes the global argmax.
+
+Because each domain tags against only its own vocabulary, a domain's cliques
+carry fewer foreign tags, so the `len(tags)` dilution above is smaller than in a
+single flat engine. On a clean single-intent utterance this changes the score
+but not the winner; on utterances carrying several intents' keywords it can
+change which intent wins.
+
+## Context
+
+A returned match feeds its matched entities into the `Session` context. On the
+next utterance the tagger seeds the Trie with those context entities (weighted
+by recency), so a `require`d slot can be satisfied from context rather than from
+the utterance's own words. This is how follow-up commands resolve. Context is
+per-session and decays as new entities arrive.
+
+## Debugging tips
+
+- **An intent scores 0** — a required slot has no tag. Confirm the exact
+  surface form is registered (matching is exact) and that multi-word keywords
+  appear contiguously.
+- **The wrong intent wins** — inspect `__tags__` on the result. Usually a
+  competing intent covered more of the utterance, or a stray keyword diluted
+  the right one. Add `require`d slots or an `exclude`.
+- **Confidence lower than expected** — short keyword, long utterance: little is
+  covered. Register longer surface forms or add `optionally` slots.
+- **Run the engine standalone** — drop the messagebus and call
+  `determine_intent` directly (see [Quickstart](quickstart.md)); print every
+  yielded result, not just the best, to see the full ranking.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart
+
+## Install
+
+```bash
+pip install ovos-adapt-pipeline-plugin
+```
+
+This pulls in the OVOS pipeline plugin and the bundled adapt parser.
+
+## Match an utterance with the engine directly
+
+The adapt parser works standalone — no OVOS, no messagebus. This is the fastest
+way to see it work and the best way to prototype intents.
+
+```python
+from ovos_adapt.intent import IntentBuilder
+from ovos_adapt.engine import IntentDeterminationEngine
+
+engine = IntentDeterminationEngine()
+
+# 1. register vocabulary: surface forms grouped by entity type
+for word in ["weather", "forecast"]:
+    engine.register_entity(word, "WeatherKeyword")
+for city in ["Seattle", "San Francisco", "Tokyo"]:
+    engine.register_entity(city, "Location")
+for kind in ["snow", "rain", "wind", "sun"]:
+    engine.register_entity(kind, "WeatherType")
+
+# 2. build an intent over those entity types
+weather = IntentBuilder("WeatherIntent") \
+    .require("WeatherKeyword") \
+    .require("Location") \
+    .optionally("WeatherType") \
+    .build()
+engine.register_intent_parser(weather)
+
+# 3. match
+for intent in engine.determine_intent("what is the rain forecast in Tokyo"):
+    if intent.get("confidence", 0) > 0:
+        print(intent)
+```
+
+Output (abridged):
+
+```python
+{'intent_type': 'WeatherIntent',
+ 'WeatherKeyword': 'forecast',
+ 'Location': 'Tokyo',
+ 'WeatherType': 'rain',
+ 'confidence': 0.72}
+```
+
+`determine_intent` yields one result per clique, best first. Filter on
+`confidence > 0` — a zero score means a required slot was missing.
+
+More runnable examples ship in the [`examples/`](../examples) folder.
+
+## Enable the pipeline in OVOS
+
+In a full OVOS install the plugin runs as a pipeline stage. Add its entry-point
+id to the pipeline list in `mycroft.conf`:
+
+```json
+{
+  "intents": {
+    "pipeline": [
+      "ovos-adapt-pipeline-plugin-high",
+      "ovos-padatious-pipeline-plugin-high",
+      "ovos-adapt-pipeline-plugin-medium",
+      "ovos-adapt-pipeline-plugin-low"
+    ]
+  }
+}
+```
+
+The `-high` / `-medium` / `-low` suffixes select the confidence tier for that
+slot in the pipeline (see [Configuration](configuration.md)). Skills then
+register their vocabulary and intents over the messagebus; the plugin matches
+incoming utterances automatically. You do not call the engine yourself — see
+[Bus protocol](bus-protocol.md) for what happens under the hood.
+
+## Next
+
+- [Writing intents](writing-intents.md) — `require` / `optionally` / `one_of` /
+  `exclude`, regex entities, and full examples.
+- [Configuration](configuration.md) — tune the confidence thresholds.

--- a/docs/writing-intents.md
+++ b/docs/writing-intents.md
@@ -1,0 +1,148 @@
+# Writing intents
+
+This page is the practical reference for defining vocabulary and intents.
+
+## Registering vocabulary
+
+Vocabulary is registered on the engine as `(surface_form, entity_type)` pairs.
+Register every form a user might say:
+
+```python
+engine.register_entity("lights", "LightKeyword")
+engine.register_entity("light", "LightKeyword")
+engine.register_entity("lamp", "LightKeyword")
+```
+
+All three are type `LightKeyword`; an intent that requires `LightKeyword`
+matches if any one of them appears. Matching is exact and case-insensitive —
+register plurals, contractions, and synonyms explicitly.
+
+### Aliases
+
+`alias_of` records that one surface form should be reported as another — useful
+when several spellings should resolve to one canonical value:
+
+```python
+engine.register_entity("NYC", "City", alias_of="New York")
+```
+
+A match on `NYC` reports the value `New York`.
+
+## Building intents
+
+`IntentBuilder` is a fluent builder. Chain rules, then `build()`:
+
+```python
+from ovos_adapt.intent import IntentBuilder
+
+intent = IntentBuilder("kitchen.lights:turn_off") \
+    .require("OffKeyword") \
+    .require("LightKeyword") \
+    .optionally("RoomKeyword") \
+    .build()
+engine.register_intent_parser(intent)
+```
+
+### `require(entity_type)`
+
+The intent only fires when a tag of this type is present. Missing any required
+type scores the intent **zero**. Use `require` for the words that define the
+command.
+
+### `optionally(entity_type)`
+
+Used when present, ignored when absent. An optional tag that *is* found raises
+the confidence (it explains more of the utterance) but never blocks a match.
+Use it for refinements — a room name, a media genre.
+
+### `one_of([entity_type, ...])`
+
+At least one type from the list must be present. Use it when a command can be
+triggered several equivalent ways:
+
+```python
+IntentBuilder("media:stop") \
+    .one_of(["StopKeyword", "PauseKeyword", "HaltKeyword"]) \
+    .require("MediaKeyword") \
+    .build()
+```
+
+### `exclude(entity_type)`
+
+The intent is rejected outright if a tag of this type is present. Use it to
+keep two similar intents apart:
+
+```python
+# "play music" but NOT "stop music"
+IntentBuilder("media:play") \
+    .require("PlayKeyword") \
+    .require("MediaKeyword") \
+    .exclude("StopKeyword") \
+    .build()
+```
+
+## Regex entities
+
+For values you cannot enumerate — numbers, free text — register a regular
+expression with a named group. The group name becomes the entity type.
+
+```python
+engine.register_regex_entity(r"for (?P<Duration>\d+) minutes")
+```
+
+A match on *"set a timer for 10 minutes"* produces a `Duration` tag with value
+`10`. Use regex entities for slots; keep `require`/`optionally` keywords for the
+words that identify the command.
+
+## A complete example
+
+```python
+from ovos_adapt.intent import IntentBuilder
+from ovos_adapt.engine import IntentDeterminationEngine
+
+engine = IntentDeterminationEngine()
+
+for w in ["turn on", "switch on"]:
+    engine.register_entity(w, "OnKeyword")
+for w in ["turn off", "switch off"]:
+    engine.register_entity(w, "OffKeyword")
+for w in ["light", "lights", "lamp"]:
+    engine.register_entity(w, "LightKeyword")
+for w in ["kitchen", "bedroom", "hallway"]:
+    engine.register_entity(w, "RoomKeyword")
+
+engine.register_intent_parser(
+    IntentBuilder("lights:on")
+    .require("OnKeyword").require("LightKeyword")
+    .optionally("RoomKeyword").build())
+
+engine.register_intent_parser(
+    IntentBuilder("lights:off")
+    .require("OffKeyword").require("LightKeyword")
+    .optionally("RoomKeyword").build())
+
+for intent in engine.determine_intent("switch on the kitchen lights"):
+    if intent.get("confidence", 0) > 0:
+        print(intent["intent_type"], intent.get("RoomKeyword"))
+        # -> lights:on kitchen
+```
+
+## Tips
+
+- **Name intents `skill_id:intent_name`.** OVOS routes a match back to the
+  skill by the `skill_id` prefix; the colon convention is expected.
+- **Multi-word keywords must be contiguous.** `"turn off"` is registered as one
+  surface form and only tags when those words appear together. `"turn the
+  lights off"` will *not* match the keyword `"turn off"`.
+- **More `require`d slots = a sharper, higher-confidence intent.** A
+  single-keyword intent fires on that lone word in any sentence; a two-slot
+  intent demands a real command shape.
+- **Disambiguate overlapping intents** with `exclude`, not by hoping confidence
+  sorts them out.
+
+## In an OVOS skill
+
+Skills built with `ovos-workshop` do not call the engine directly — they
+register vocabulary and intents over the messagebus, and this plugin consumes
+those messages. The `IntentBuilder` API above is exactly what the skill side
+uses. See [Bus protocol](bus-protocol.md) for the message flow.


### PR DESCRIPTION
## Summary

Adds a `docs/` guide for the Adapt pipeline plugin — zero to hero, for both
newcomers and developers extending the plugin.

| Page | Audience | Contents |
|---|---|---|
| [index](docs/index.md) | all | what the plugin is, reading order, where Adapt fits |
| [concepts](docs/concepts.md) | newcomer | theory — entities, intents, cliques, the confidence model; no prior knowledge assumed |
| [quickstart](docs/quickstart.md) | newcomer | install, a runnable standalone example, enabling the pipeline in `mycroft.conf` |
| [writing-intents](docs/writing-intents.md) | skill author | `require` / `optionally` / `one_of` / `exclude`, aliases, regex entities, full worked examples, tips |
| [configuration](docs/configuration.md) | integrator | entry point, confidence tiers, every config key, tuning advice |
| [bus-protocol](docs/bus-protocol.md) | advanced | the messagebus contract — registration messages, query messages, match flow, sessions |
| [internals](docs/internals.md) | advanced | the `determine_intent` pipeline, clique expansion, the confidence formula derived from source, the domain engine, debugging |

Practical examples throughout; theory in `concepts.md` and `internals.md`. The
README links the guide.

Documents the package as it stands on `dev`; independent of other open PRs.

## Test plan
- [x] Docs only — no code changes
- [x] All code snippets follow the bundled `examples/` and the engine API

🤖 Generated with [Claude Code](https://claude.com/claude-code)