### PR TITLE
fix: bucket engines by full BCP-47 tag, migrate to ovos-spec-tools

### DIFF
--- a/ovos_adapt/opm.py
+++ b/ovos_adapt/opm.py
@@ -17,16 +17,15 @@ from functools import lru_cache
 from threading import Lock
 from typing import List, Optional, Iterable, Union, Dict
 
-from langcodes import closest_match
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager
 from ovos_bus_client.util import get_message_lang
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
+from ovos_spec_tools import closest_lang, standardize_lang
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 from ovos_workshop.intents import open_intent_envelope
 
@@ -58,11 +57,11 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
         core_config = Configuration()
         config = config or core_config.get("context", {})  # legacy mycroft-core path
         super().__init__(bus, config)
-        self.lang = standardize_lang_tag(core_config.get("lang", "en-US"))
+        self.lang = standardize_lang(core_config.get("lang", "en-US"))
         langs = core_config.get('secondary_langs') or []
         if self.lang not in langs:
             langs.append(self.lang)
-        langs = [standardize_lang_tag(l) for l in langs]
+        langs = [standardize_lang(l) for l in langs]
         self.engines = {lang: IntentDeterminationEngine()
                         for lang in langs}
 
@@ -217,14 +216,7 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
 
     def _get_closest_lang(self, lang: str) -> Optional[str]:
         if self.engines:
-            lang = standardize_lang_tag(lang)
-            closest, score = closest_match(lang, list(self.engines.keys()))
-            # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
-            # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
-            # 1- 3 -> These codes indicate a minor regional difference.
-            # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
-            if score < 10:
-                return closest
+            return closest_lang(lang, list(self.engines.keys()))
         return None
 
     def register_vocabulary(self, entity_value: str, entity_type: str,
@@ -240,8 +232,8 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
             entity_type: the type/tag of an entity instance
             alias_of: entity this is an alternative for
         """
-        lang = standardize_lang_tag(lang)
-        if lang in self.engines:
+        lang = self._get_closest_lang(lang)
+        if lang is not None:
             with self.lock:
                 if regex_str:
                     self.engines[lang].register_regex_entity(regex_str)
@@ -323,7 +315,9 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
 
     @property
     def registered_intents(self):
-        lang = get_message_lang()
+        lang = self._get_closest_lang(get_message_lang())
+        if lang is None:
+            return []
         return [parser.__dict__ for parser in self.engines[lang].intent_parsers]
 
     def handle_register_vocab(self, message):
@@ -438,11 +432,11 @@ class DomainAdaptPipeline(AdaptPipeline):
         # Skip AdaptPipeline.__init__ to avoid building a flat engine; call
         # the grandparent initializer directly.
         ConfidenceMatcherPipeline.__init__(self, bus, config)
-        self.lang = standardize_lang_tag(core_config.get("lang", "en-US"))
+        self.lang = standardize_lang(core_config.get("lang", "en-US"))
         langs = core_config.get('secondary_langs') or []
         if self.lang not in langs:
             langs.append(self.lang)
-        langs = [standardize_lang_tag(l) for l in langs]
+        langs = [standardize_lang(l) for l in langs]
         self.engines = {lang: self._engine_class()
                         for lang in langs}
 
@@ -580,8 +574,8 @@ class DomainAdaptPipeline(AdaptPipeline):
     def register_vocabulary(self, entity_value: str, entity_type: str,
                             alias_of: str, regex_str: str, lang: str):
         """Register skill vocabulary, routed by entity_type to a domain."""
-        lang = standardize_lang_tag(lang)
-        if lang in self.engines:
+        lang = self._get_closest_lang(lang)
+        if lang is not None:
             with self.lock:
                 domain = self._resolve_entity_domain(lang, entity_type)
                 if regex_str:
@@ -621,7 +615,9 @@ class DomainAdaptPipeline(AdaptPipeline):
 
     @property
     def registered_intents(self):
-        lang = get_message_lang()
+        lang = self._get_closest_lang(get_message_lang())
+        if lang is None:
+            return []
         out = []
         for sub in self.engines[lang].domains.values():
             out.extend(parser.__dict__ for parser in sub.intent_parsers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "ovos-plugin-manager>=0.5.0,<3.0.0",
     "ovos-workshop>=0.1.7,<9.0.0",
     "ovos-utils>=0.3.4,<1.0.0",
+    "ovos-spec-tools>=0.1.0,<1.0.0",
     "langcodes",
 ]
 


### PR DESCRIPTION
## Summary

Migrate the adapt pipeline plugin onto `ovos-spec-tools`:

- `ovos_utils.lang.standardize_lang_tag` (which defaults to `macro=True` and silently strips region) is replaced with `ovos_spec_tools.standardize_lang`, which preserves the full normalized BCP-47 tag.
- The local `langcodes.closest_match` + `score < 10` reconciliation inside `_get_closest_lang` is replaced with `ovos_spec_tools.closest_lang(target, available)`.
- Registration handlers (`register_vocabulary` on both `AdaptPipeline` and `DomainAdaptPipeline`, plus the `registered_intents` properties) now route incoming lang values to the correct engine bucket via `_get_closest_lang` instead of macro-stripping.

## Why

Engines were keyed by macro language (e.g. `en`) while skills registered resources for full BCP-47 tags (e.g. `en-US`). After the upstream `ovos-utils` deprecation of `standardize_lang_tag`, that coincidental collision became fragile. Bucketing by full tag and reconciling at match time via `closest_lang` is the policy used across the rest of the OVOS spec adoption.

## Behaviour change

`adapt.engines.keys()` is now `['en-US']` rather than `['en']` for the default configuration. Verified:

```python
>>> from ovos_adapt.opm import AdaptPipeline
>>> AdaptPipeline().engines.keys()
dict_keys(['en-US'])
```

## Tests

`pytest` is green (104 passed) after the migration.

## Fix

Adapt engines now bucket by full BCP-47 tag. Resource registrations whose lang differs from the configured pipeline lang (e.g. registering `en-GB` vocab into an `en-US` pipeline) previously collided by coincidence after macro-stripping and now go through the per-match `closest_lang` reconciliation. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)