### PR TITLE
fix: guard None session blacklists in intent match filters

### DIFF
--- a/ovos_adapt/opm.py
+++ b/ovos_adapt/opm.py
@@ -178,8 +178,8 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
             best = best_intent.get('confidence', 0.0) if best_intent else 0.0
             conf = intent.get('confidence', 0.0)
             skill = intent['intent_type'].split(":")[0]
-            if best < conf and intent["intent_type"] not in sess.blacklisted_intents \
-                    and skill not in sess.blacklisted_skills:
+            if best < conf and intent["intent_type"] not in (sess.blacklisted_intents or []) \
+                    and skill not in (sess.blacklisted_skills or []):
                 best_intent = intent
                 # TODO - Shouldn't Adapt do this?
                 best_intent['utterance'] = utt
@@ -532,8 +532,8 @@ class DomainAdaptPipeline(AdaptPipeline):
             best = best_intent.get('confidence', 0.0) if best_intent else 0.0
             conf = intent.get('confidence', 0.0)
             skill = intent['intent_type'].split(":")[0]
-            if best < conf and intent["intent_type"] not in sess.blacklisted_intents \
-                    and skill not in sess.blacklisted_skills:
+            if best < conf and intent["intent_type"] not in (sess.blacklisted_intents or []) \
+                    and skill not in (sess.blacklisted_skills or []):
                 best_intent = intent
                 best_intent['utterance'] = utt
 


### PR DESCRIPTION
ovos-bus-client 2.4.x can surface `Session.blacklisted_intents` / `blacklisted_skills` as `None` (optional SESSION-1 fields). The membership tests in `match_intent` (`intent_type not in sess.blacklisted_intents`, `skill not in sess.blacklisted_skills`) then raised `TypeError: argument of type 'NoneType' is not iterable`, aborting every adapt match — the utterance fell through to `complete_intent_failure`/error-sound instead of dispatching.

Reproduced in ovos-core's e2e suite (`test_adapt.py::test_adapt_match`) against the integrated spec stack (bus-client@feat/session-spec-fields): adapt emitted only 4 messages (utterance, play_sound, intent_failure, handled) instead of the full 8. Guarding the blacklists as `(... or [])` restores the full match → 8 messages, both spec and legacy namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)