### PR TITLE
fix: accept foreign (ovos-spec-tools / ovos-workshop) Intents at registration

### DIFF
--- a/ovos_adapt/engine.py
+++ b/ovos_adapt/engine.py
@@ -22,6 +22,7 @@ from ovos_adapt.entity_tagger import EntityTagger
 from ovos_adapt.parser import Parser
 from ovos_adapt.tools.text.tokenizer import EnglishTokenizer
 from ovos_adapt.tools.text.trie import Trie
+from ovos_adapt.intent import Intent
 
 __author__ = 'seanfitz'
 
@@ -233,6 +234,22 @@ class IntentDeterminationEngine(object):
         Raises:
             ValueError: on invalid intent
         """
+        # Intents built via the shared ovos-spec-tools primitive (e.g.
+        # ovos-workshop re-exporting IntentBuilder) carry the same fields but
+        # lack adapt's matching API (validate / validate_with_tags). Rebuild
+        # them as an adapt Intent so they can be matched. Skills registering
+        # over the bus already get this via open_intent_envelope; this covers
+        # direct in-process registration.
+        if not (hasattr(intent_parser, 'validate_with_tags') and
+                callable(getattr(intent_parser, 'validate_with_tags', None))):
+            if all(hasattr(intent_parser, attr) for attr in
+                   ('name', 'requires', 'at_least_one', 'optional', 'excludes')):
+                intent_parser = Intent(intent_parser.name,
+                                       intent_parser.requires,
+                                       intent_parser.at_least_one,
+                                       intent_parser.optional,
+                                       intent_parser.excludes)
+
         if hasattr(intent_parser, 'validate') and callable(intent_parser.validate):
             self.intent_parsers.append(intent_parser)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "six>=1.10.0",
-    "ovos-plugin-manager>=0.5.0,<3.0.0",
+    "ovos-plugin-manager>=2.4.0a1,<3.0.0",
     "ovos-utils>=0.3.4,<1.0.0",
-    "ovos-spec-tools>=0.16.0a1,<1.0.0",
+    "ovos_bus_client>=2.5.1a1,<3.0.0",
+    "ovos-spec-tools>=0.16.1a2,<1.0.0",
     "langcodes",
 ]
 

--- a/test/test_register_foreign_intent.py
+++ b/test/test_register_foreign_intent.py
@@ -1,0 +1,48 @@
+"""adapt's engine must accept Intents built outside adapt — e.g. the bare
+ovos-spec-tools Intent that ovos-workshop re-exports via IntentBuilder — by
+coercing them to an adapt Intent at registration. Skills registering over the
+bus already get this via open_intent_envelope; this covers direct in-process
+registration (library use / test harnesses)."""
+import unittest
+
+from ovos_adapt.engine import IntentDeterminationEngine
+from ovos_adapt.intent import IntentBuilder as AdaptBuilder
+from ovos_spec_tools.intent import IntentBuilder as SpecBuilder
+
+
+class TestRegisterForeignIntent(unittest.TestCase):
+    def test_spec_tools_intent_is_coerced(self):
+        engine = IntentDeterminationEngine()
+        foreign = SpecBuilder("LightIntent").require("LightKeyword").build()
+        # the bare spec-tools Intent lacks adapt's matching API
+        self.assertFalse(hasattr(foreign, "validate_with_tags"))
+        engine.register_intent_parser(foreign)  # must not raise
+        self.assertEqual(len(engine.intent_parsers), 1)
+        # rebuilt as an adapt Intent — now matchable
+        self.assertTrue(hasattr(engine.intent_parsers[0], "validate_with_tags"))
+
+    def test_foreign_intent_matches(self):
+        engine = IntentDeterminationEngine()
+        engine.register_entity("light", "LightKeyword")
+        engine.register_entity("on", "OnKeyword")
+        foreign = (SpecBuilder("LightIntent")
+                   .require("OnKeyword").require("LightKeyword").build())
+        engine.register_intent_parser(foreign)
+        intents = list(engine.determine_intent("turn on the light"))
+        self.assertTrue(intents)
+        self.assertEqual(intents[0].get("intent_type"), "LightIntent")
+
+    def test_native_adapt_intent_passes_through_unchanged(self):
+        engine = IntentDeterminationEngine()
+        native = AdaptBuilder("NativeIntent").require("LightKeyword").build()
+        engine.register_intent_parser(native)
+        self.assertIs(engine.intent_parsers[0], native)
+
+    def test_non_intent_still_rejected(self):
+        engine = IntentDeterminationEngine()
+        with self.assertRaises(ValueError):
+            engine.register_intent_parser("NOTAPARSER")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
ovos-workshop re-exports `IntentBuilder` straight from ovos-spec-tools, so `IntentBuilder(...).build()` now returns a bare `ovos_spec_tools.intent.Intent`. That Intent carries the same fields (`name`, `requires`, `at_least_one`, `optional`, `excludes`) but **lacks adapt's matching API** (`validate` / `validate_with_tags`, which live on adapt's `Intent(_SpecIntent)` subclass).

- **Skills registering over the bus are NOT affected** — `register_adapt_intent` emits `register_intent` with `intent_parser.__dict__`, and adapt's `open_intent_envelope` rebuilds an adapt Intent from those keys.
- **Direct in-process `engine.register_intent_parser(intent)`** (library use / test harnesses) raised `ValueError: ... is not an intent parser` because the bare Intent has no `validate`.

## Fix
In `IntentDeterminationEngine.register_intent_parser`, rebuild any intent-shaped parser that lacks `validate_with_tags` into an adapt `Intent` from its shared fields, before the interface check. Mirrors what the bus path already does via `open_intent_envelope`.

- Native adapt Intents pass through unchanged (same object).
- Truly invalid inputs (e.g. a string) still raise `ValueError`.

## Tests
New `test/test_register_foreign_intent.py`: a bare spec-tools Intent registers + matches; native adapt Intent passes through unchanged; non-intent still rejected. Full unit suite green (97 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)