### PR TITLE
feat: OVOS-CONTEXT-1 §7 pre-match context injection (keyword engine)

### DIFF
--- a/ovos_adapt/opm.py
+++ b/ovos_adapt/opm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """An intent parsing service using the Adapt parser."""
+import time
 from functools import lru_cache
 from threading import Lock
 from typing import List, Optional, Iterable, Union, Dict
@@ -23,7 +24,7 @@ from ovos_bus_client.session import SessionManager
 from ovos_bus_client.util import get_message_lang
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
-from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage, gate_satisfied
+from ovos_spec_tools import closest_lang, standardize_lang, SpecMessage, gate_satisfied, is_live
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
@@ -47,6 +48,25 @@ def _entity_skill_id(skill_id):
     skill_id = skill_id.replace('.', '_')
     skill_id = skill_id.replace('-', '_')
     return skill_id
+
+
+class _InjectedContextManager:
+    """Adapt context source backed by ``session.intent_context`` (CONTEXT-1 §7).
+
+    Presents pre-match context candidates through the same ``get_context``
+    surface the legacy frame-stack :class:`~ovos_adapt.context.ContextManager`
+    exposes, so the adapt matcher consumes them exactly as it consumed legacy
+    ``from_context`` tags -- but sourced from the canonical intent-context map
+    rather than the frame stack. Each candidate is an entity dict of the shape
+    the parser and :meth:`Intent.validate_with_tags` expect.
+    """
+
+    def __init__(self, entities):
+        self._entities = entities
+
+    def get_context(self, *args, **kwargs):
+        # copies: the parser sorts and mutates the returned list in place.
+        return [dict(entity) for entity in self._entities]
 
 
 class AdaptPipeline(ConfidenceMatcherPipeline):
@@ -87,6 +107,13 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
         # OVOS-CONTEXT-1 gate declarations, keyed by adapt intent label
         # (``skill_id:intent_name``): {'requires': [...], 'excludes': [...]}.
         self._context_gates: Dict[str, Dict] = {}
+
+        # OVOS-CONTEXT-1 §7 injection index, keyed by adapt intent label:
+        # {'skill_id': str, 'keywords': {vocab_name: adapt_entity_type}}. Maps
+        # each intent's declared keyword names to the entity_type its matcher
+        # requires, so a live context entry of that name can be injected as a
+        # candidate keyword before matching.
+        self._intent_keywords: Dict[str, Dict] = {}
 
         self._register_spec_handlers()
 
@@ -196,7 +223,7 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
                 intents = [i for i in self.engines[lang].determine_intent(
                     utt, 100,
                     include_tags=True,
-                    context_manager=sess.context)
+                    context_manager=self._context_manager(sess))
                     if self._context_gate_ok(i, sess)]
                 if intents:
                     utt_best = max(
@@ -259,6 +286,91 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
                               gate['requires'], gate['excludes'],
                               owner_id=skill_id)
 
+    @staticmethod
+    def _live_context_value(entries: Dict, name: str, skill_id: str,
+                            now: float) -> Optional[str]:
+        """Resolve a live non-null string context value for a keyword name.
+
+        Scope is read from the key (OVOS-CONTEXT-1 §3): the owner's private
+        entry ``<skill_id>:<name>`` is consulted first, then the shared bare
+        ``<name>``. Flag entries (``value`` null / non-string) and dead
+        entries are ignored.
+        """
+        for key in (f"{skill_id}:{name}", name):
+            entry = entries.get(key)
+            if not isinstance(entry, dict):
+                continue
+            value = entry.get("value")
+            if not isinstance(value, str) or not value:
+                continue
+            if not is_live(entry, now):
+                continue
+            return value
+        return None
+
+    def _context_candidate_entities(self, sess) -> List[Dict]:
+        """Build OVOS-CONTEXT-1 §7 pre-match candidate entities.
+
+        For every registered intent keyword that has a live non-null string
+        entry in ``session.intent_context`` (scope-resolved from the key),
+        emit an adapt context entity of that keyword's ``entity_type`` carrying
+        the entry value. The matcher then treats the value as it would a
+        keyword the utterance produced; an entity the utterance itself yields
+        for the same type is found first by ``_find_first_tag`` and wins.
+        """
+        entries = getattr(sess, "intent_context", None) or {}
+        if not entries or not self._intent_keywords:
+            return []
+        now = time.time()
+        seen = set()
+        candidates = []
+        for meta in self._intent_keywords.values():
+            skill_id = meta["skill_id"]
+            for name, entity_type in meta["keywords"].items():
+                value = self._live_context_value(entries, name, skill_id, now)
+                if value is None:
+                    continue
+                dedup = (entity_type, value)
+                if dedup in seen:
+                    continue
+                seen.add(dedup)
+                candidates.append({"key": value, "match": value,
+                                   "confidence": 1.0,
+                                   "data": [(value, entity_type)]})
+        return candidates
+
+    def _context_manager(self, sess) -> _InjectedContextManager:
+        """Context source for a match, sourced from ``session.intent_context``."""
+        return _InjectedContextManager(self._context_candidate_entities(sess))
+
+    def _record_intent_keywords(self, intent):
+        """Index an intent's declared keyword names for §7 injection.
+
+        Records every ``require`` / ``optional`` / ``one_of`` entity_type keyed
+        by the label's ``skill_id``. For legacy and in-process registrations
+        the keyword name is the entity_type itself; the OVOS-INTENT-4 keyword
+        handler overrides this with the un-namespaced vocabulary names.
+        """
+        name = getattr(intent, "name", None)
+        if not name:
+            return
+        keywords = {}
+        for entity_type, _attr in (list(getattr(intent, "requires", []) or []) +
+                                   list(getattr(intent, "optional", []) or [])):
+            keywords[entity_type] = entity_type
+        for group in getattr(intent, "at_least_one", []) or []:
+            for entity_type in group:
+                keywords[entity_type] = entity_type
+        skill_id = name.split(":", 1)[0] if ":" in name else name
+        self._intent_keywords[name] = {"skill_id": skill_id,
+                                       "keywords": keywords}
+
+    def _forget_intent_keywords(self, skill_id: str):
+        """Drop the §7 injection index entries owned by a detached skill."""
+        for label in [l for l, m in self._intent_keywords.items()
+                      if m["skill_id"] == skill_id]:
+            self._intent_keywords.pop(label, None)
+
     def register_vocabulary(self, entity_value: str, entity_type: str,
                             alias_of: str, regex_str: str, lang: str):
         """Register skill vocabulary as adapt entity.
@@ -290,6 +402,8 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
         for lang in self.engines:
             with self.lock:
                 self.engines[lang].register_intent_parser(intent)
+        # OVOS-CONTEXT-1 §7 — index declared keywords for candidate injection.
+        self._record_intent_keywords(intent)
 
     def detach_skill(self, skill_id):
         """Remove all intents for skill.
@@ -306,6 +420,7 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
                 self.engines[lang].drop_intent_parser(skill_parsers)
             self._detach_skill_keywords(skill_id)
             self._detach_skill_regexes(skill_id)
+        self._forget_intent_keywords(skill_id)
 
     def _detach_skill_keywords(self, skill_id):
         """Detach all keywords registered with a particular skill.
@@ -347,6 +462,7 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
                 p for p in self.engines[lang].intent_parsers if p.name != intent_name
             ]
             self.engines[lang].intent_parsers = new_parsers
+        self._intent_keywords.pop(intent_name, None)
 
     def shutdown(self):
         for lang in self.engines:
@@ -575,9 +691,25 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
                 builder.exclude(entity_type)
 
         self.register_intent(builder.build())
+        label = self._spec_intent_name(skill_id, intent_name)
+        # OVOS-CONTEXT-1 §7 — map the un-namespaced vocabulary names to the
+        # namespaced adapt entity_types so a context entry keyed by the bare
+        # name (e.g. ``person``) injects a candidate for this intent's keyword.
+        keyword_types = {}
+        for descriptor in list(required) + list(optional):
+            n = descriptor.get("name")
+            if n:
+                keyword_types[n] = self._spec_entity_type(skill_id, n)
+        for group in one_of:
+            for descriptor in group:
+                n = descriptor.get("name")
+                if n:
+                    keyword_types[n] = self._spec_entity_type(skill_id, n)
+        self._intent_keywords[label] = {"skill_id": skill_id,
+                                        "keywords": keyword_types}
         # OVOS-CONTEXT-1 §6 — the register payload MAY declare context gates.
         self._store_context_gate(
-            self._spec_intent_name(skill_id, intent_name),
+            label,
             data.get("requires_context"), data.get("excludes_context"))
 
     def handle_spec_register_entity(self, message):
@@ -726,6 +858,8 @@ class DomainAdaptPipeline(AdaptPipeline):
 
         # OVOS-CONTEXT-1 gate declarations, keyed by adapt intent label.
         self._context_gates: Dict[str, Dict] = {}
+        # OVOS-CONTEXT-1 §7 injection index (see AdaptPipeline.__init__).
+        self._intent_keywords: Dict[str, Dict] = {}
 
         self.bus.on('register_vocab', self.handle_register_vocab)
         self.bus.on('register_intent', self.handle_register_intent)
@@ -770,7 +904,7 @@ class DomainAdaptPipeline(AdaptPipeline):
         for sub in sub_engines:
             for it in sub.determine_intent(
                     utterance=utt, num_results=1, include_tags=True,
-                    context_manager=sess.context):
+                    context_manager=self._context_manager(sess)):
                 if self._context_gate_ok(it, sess):
                     candidates.append(it)
         return candidates
@@ -845,6 +979,8 @@ class DomainAdaptPipeline(AdaptPipeline):
             with self.lock:
                 self.engines[lang].register_intent_parser(intent, domain=domain)
                 self._entity_domain_index[lang][norm] = domain
+        # OVOS-CONTEXT-1 §7 — index declared keywords for candidate injection.
+        self._record_intent_keywords(intent)
 
     def register_vocabulary(self, entity_value: str, entity_type: str,
                             alias_of: str, regex_str: str, lang: str):
@@ -871,6 +1007,7 @@ class DomainAdaptPipeline(AdaptPipeline):
                 idx = self._entity_domain_index.get(lang, {})
                 for prefix in [p for p, d in idx.items() if d == skill_id]:
                     idx.pop(prefix, None)
+        self._forget_intent_keywords(skill_id)
 
     def detach_intent(self, intent_name):
         """Detach a single intent from its owning domain."""
@@ -882,6 +1019,7 @@ class DomainAdaptPipeline(AdaptPipeline):
                     sub = engine.domains[domain]
                     sub.intent_parsers = [p for p in sub.intent_parsers
                                           if p.name != intent_name]
+        self._intent_keywords.pop(intent_name, None)
 
     def shutdown(self):
         with self.lock:
@@ -917,5 +1055,5 @@ class HierarchicalAdaptPipeline(DomainAdaptPipeline):
         with self.lock:
             candidates = list(engine.determine_intent(
                 utterance=utt, num_results=1, include_tags=True,
-                context_manager=sess.context))
+                context_manager=self._context_manager(sess)))
         return [it for it in candidates if self._context_gate_ok(it, sess)]

--- a/test/test_context1_injection.py
+++ b/test/test_context1_injection.py
@@ -1,0 +1,96 @@
+# Copyright 2024 OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""OVOS-CONTEXT-1 §7 pre-match context injection for the adapt keyword engine.
+
+A live non-null string entry in ``session.intent_context`` is injected as a
+candidate keyword for the vocabulary of the same name **before** matching, so
+an intent requiring that keyword can match even when the utterance lacks it.
+An utterance-produced value for the same keyword wins over the injected one,
+and a flag entry (``value=null``) is never injected -- it only gates (see the
+requires_context gating contract).
+"""
+from unittest import TestCase, mock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from ovos_adapt.intent import IntentBuilder
+from ovos_adapt.opm import AdaptPipeline
+
+SKILL_ID = "bio.skill"
+INTENT = f"{SKILL_ID}:height_query"
+
+
+class TestContext1Injection(TestCase):
+    def setUp(self):
+        self.pipeline = AdaptPipeline(mock.Mock())
+        # A keyword intent requiring a `tall_query` phrase and a `person`
+        # keyword; `person` names both a required vocabulary and the reported
+        # slot. The utterance "how tall is he" never fills `person`.
+        self.pipeline.register_vocabulary("how tall is", "tall_query",
+                                          None, None, "en-US")
+        self.pipeline.register_vocabulary("bob", "person", None, None, "en-US")
+        self.pipeline.register_vocabulary("alice", "person", None, None,
+                                          "en-US")
+        intent = IntentBuilder(INTENT).require("tall_query").require(
+            "person").build()
+        self.pipeline.register_intent(intent)
+
+    def _match(self, utterance, intent_context=None):
+        sess = Session("sess")
+        sess.intent_context = intent_context or {}
+        msg = Message("intent.service.adapt.get",
+                      data={"utterance": utterance, "lang": "en-US"},
+                      context={"session": sess.serialize()})
+        self.pipeline.handle_get_adapt(msg)
+        return self.pipeline.bus.emit.call_args[0][0].data["intent"]
+
+    def test_no_context_no_match(self):
+        """Without a live `person` entry the person keyword stays unfilled."""
+        self.assertIsNone(self._match("how tall is he"))
+
+    def test_shared_context_injected_as_keyword(self):
+        """A live shared {person: Bob} fills the person keyword and slot."""
+        ctx = {"person": {"value": "Bob"}}
+        intent = self._match("how tall is he", intent_context=ctx)
+        self.assertIsNotNone(intent)
+        self.assertEqual(intent["intent_type"], INTENT)
+        self.assertEqual(intent["person"], "Bob")
+
+    def test_private_owner_context_injected(self):
+        """A live private <skill_id>:person entry fills the owner's keyword."""
+        ctx = {f"{SKILL_ID}:person": {"value": "Bob"}}
+        intent = self._match("how tall is he", intent_context=ctx)
+        self.assertIsNotNone(intent)
+        self.assertEqual(intent["person"], "Bob")
+
+    def test_utterance_value_wins_over_context(self):
+        """A person keyword in the utterance beats the injected candidate."""
+        ctx = {"person": {"value": "Alice"}}
+        intent = self._match("how tall is bob", intent_context=ctx)
+        self.assertIsNotNone(intent)
+        # adapt normalizes registered vocabulary to lowercase; the point is
+        # the utterance value ("bob"), not the injected context ("Alice").
+        self.assertEqual(intent["person"], "bob")
+
+    def test_flag_entry_not_injected(self):
+        """A null-valued (flag) entry gates only -- it is never injected."""
+        ctx = {"person": {"value": None}}
+        self.assertIsNone(self._match("how tall is he", intent_context=ctx))
+
+    def test_expired_entry_not_injected(self):
+        """A dead entry (turns_remaining<=0) is not injected."""
+        ctx = {"person": {"value": "Bob", "turns_remaining": 0}}
+        self.assertIsNone(self._match("how tall is he", intent_context=ctx))


### PR DESCRIPTION
Implements OVOS-CONTEXT-1 §7 pre-match **context injection** for the adapt keyword engine, building on the already-merged §6/§6.1 gating (#56).

## What
Adapt is a keyword engine, so a string-valued context entry is identical to a matched keyword. At match time every **live non-null string** entry in `session.intent_context` is injected as a candidate keyword **before** the adapt matcher runs — mirroring adapt's legacy `from_context` tag injection, but sourced from the canonical `session.intent_context` map instead of the legacy frame-stack `session.context`.

- **Scope from the key (§3):** a private `<skill_id>:<key>` entry is a candidate only for that skill's intents; a bare shared `<key>` is a candidate for any intent.
- **Existing `require()` consumes it:** an intent that requires the keyword matches; one that doesn't is unaffected. This is what makes `who is {person}?` → `how tall is he?` resolve with `person=Bob`.
- **Utterance wins:** an entity the utterance itself produces for the same keyword is found first by `_find_first_tag` and replaces the injected candidate.
- **Flags stay gates:** null-valued (flag) entries and dead entries are never injected; the existing `requires_context`/`excludes_context` gate keeps handling those.

Injection is wired into all three pipelines (flat / domain / hierarchical) via a shared `_context_manager(sess)` that returns an `_InjectedContextManager` exposing the candidates through the same `get_context()` surface the engine already consumes.

## Tests
New `test/test_context1_injection.py`: no-context→no-match; shared `{person: Bob}` injected as keyword + reported slot; private `<skill_id>:person`; utterance value wins over context; flag entry only gates; dead entry not injected. Full suite green (117 passed, 2 pre-existing ovoscope skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)