### PR TITLE
fix: never crash on partial register_vocab payloads

### DIFF
--- a/ovos_adapt/opm.py
+++ b/ovos_adapt/opm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 """An intent parsing service using the Adapt parser."""
+import re
 import time
 from functools import lru_cache
 from threading import Lock
@@ -487,6 +488,15 @@ class AdaptPipeline(ConfidenceMatcherPipeline):
         regex_str = message.data.get('regex')
         alias_of = message.data.get('alias_of')
         lang = get_message_lang(message)
+        # OVOS-INTENT-4 §6.3 — skip unusable registrations with a warning
+        # instead of crashing the executor: a payload must carry either a
+        # regex or a complete entity_value/entity_type keyword pair.
+        if not regex_str and (not entity_value or not entity_type):
+            LOG.warning(f"skipping malformed vocab registration "
+                        f"(topic={message.msg_type}, lang={lang}, "
+                        f"entity_type={entity_type}, entity_value={entity_value}): "
+                        f"missing entity_value/entity_type and no regex")
+            return
         self.register_vocabulary(entity_value, entity_type,
                                  alias_of, regex_str, lang)
         self.registered_vocab.append(message.data)
@@ -880,6 +890,10 @@ class DomainAdaptPipeline(AdaptPipeline):
         Falls back to the entity_type itself if no match is found.
         """
         index = self._entity_domain_index.get(lang, {})
+        if not entity_type:
+            # nothing to route by (e.g. a regex with no named group);
+            # fall back to the shared default domain
+            return 0
         # exact match first
         if entity_type in index:
             return index[entity_type]
@@ -987,6 +1001,12 @@ class DomainAdaptPipeline(AdaptPipeline):
         """Register skill vocabulary, routed by entity_type to a domain."""
         lang = self._get_closest_lang(lang)
         if lang is not None:
+            if regex_str and not entity_type:
+                # legacy regex payloads carry no entity_type; the named
+                # group is the entity_type (skill-id prefixed by the
+                # emitter), so route the regex to its owning domain by it
+                group = re.search(r"\(\?P<([^>]+)>", regex_str)
+                entity_type = group.group(1) if group else None
             with self.lock:
                 domain = self._resolve_entity_domain(lang, entity_type)
                 if regex_str:

--- a/test/test_register_vocab_partial_payload.py
+++ b/test/test_register_vocab_partial_payload.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Open Voice OS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""Registration payloads with missing fields must never crash the parser.
+
+OVOS-INTENT-4 (§5.3/§6.3): consumers skip malformed registrations with a
+warning and only reject a registration outright when nothing usable remains.
+
+Legacy ``register_vocab`` payloads come in two shapes:
+
+- keyword: ``{"entity_value": ..., "entity_type": ...}`` (no ``regex``)
+- regex:   ``{"regex": ...}`` (no ``entity_type``/``entity_value``)
+
+The regex shape carries no ``entity_type``, so domain routing must derive
+the owning skill from the regex named group instead of crashing on ``None``.
+"""
+from unittest import TestCase, mock
+
+from ovos_bus_client.message import Message
+
+from ovos_adapt.intent import IntentBuilder
+from ovos_adapt.opm import (AdaptPipeline, DomainAdaptPipeline,
+                            HierarchicalAdaptPipeline)
+
+
+def _register_nav_intent(pipeline):
+    intent = (IntentBuilder('nav.skill:NavIntent')
+              .require('nav_skillGoKeyword')
+              .require('nav_skillLocation'))
+    pipeline.handle_register_intent(Message('register_intent', intent.__dict__))
+
+
+class RegexVocabWithoutEntityTypeTest(TestCase):
+    """Regex registrations (no entity_type) must register, not crash."""
+
+    def test_domain_pipeline_regex_payload(self):
+        pipeline = DomainAdaptPipeline(mock.Mock())
+        _register_nav_intent(pipeline)
+        # exact legacy regex payload shape: no entity_type/entity_value
+        pipeline.handle_register_vocab(
+            Message('register_vocab',
+                    {'regex': r'to (?P<nav_skillLocation>.*)'}))
+        engine = pipeline.engines[pipeline.lang]
+        # routed to the owning skill's domain via the regex group name
+        self.assertIn(r'to (?P<nav_skillLocation>.*)',
+                      engine.domains['nav.skill']._regex_strings)
+
+    def test_hierarchical_pipeline_regex_payload(self):
+        pipeline = HierarchicalAdaptPipeline(mock.Mock())
+        _register_nav_intent(pipeline)
+        pipeline.handle_register_vocab(
+            Message('register_vocab',
+                    {'regex': r'to (?P<nav_skillLocation>.*)'}))
+        engine = pipeline.engines[pipeline.lang]
+        self.assertIn(r'to (?P<nav_skillLocation>.*)',
+                      engine.domains['nav.skill']._regex_strings)
+
+    def test_regex_without_named_group_falls_back(self):
+        pipeline = DomainAdaptPipeline(mock.Mock())
+        _register_nav_intent(pipeline)
+        # no named group -> nothing to route by; still must not crash
+        pipeline.handle_register_vocab(
+            Message('register_vocab', {'regex': r'to .*'}))
+
+    def test_regex_matches_end_to_end(self):
+        pipeline = DomainAdaptPipeline(mock.Mock())
+        _register_nav_intent(pipeline)
+        pipeline.handle_register_vocab(
+            Message('register_vocab',
+                    {'entity_value': 'go', 'entity_type': 'nav_skillGoKeyword'}))
+        pipeline.handle_register_vocab(
+            Message('register_vocab',
+                    {'regex': r'go to (?P<nav_skillLocation>.*)'}))
+        result = pipeline.match_intent(('go to lisbon',), pipeline.lang)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.match_type, 'nav.skill:NavIntent')
+
+
+class UnusableVocabPayloadTest(TestCase):
+    """Payloads with neither regex nor keyword data are skipped with a warning."""
+
+    def _check_skipped(self, pipeline):
+        before = list(pipeline.registered_vocab)
+        with mock.patch('ovos_adapt.opm.LOG.warning') as warn:
+            pipeline.handle_register_vocab(
+                Message('register_vocab', {'alias_of': 'thing'}))
+        warn.assert_called_once()
+        self.assertEqual(pipeline.registered_vocab, before)
+
+    def test_flat_pipeline_skips(self):
+        self._check_skipped(AdaptPipeline(mock.Mock()))
+
+    def test_domain_pipeline_skips(self):
+        pipeline = DomainAdaptPipeline(mock.Mock())
+        _register_nav_intent(pipeline)
+        self._check_skipped(pipeline)
+
+    def test_keyword_payload_missing_value_skipped(self):
+        pipeline = DomainAdaptPipeline(mock.Mock())
+        _register_nav_intent(pipeline)
+        before = list(pipeline.registered_vocab)
+        with mock.patch('ovos_adapt.opm.LOG.warning') as warn:
+            pipeline.handle_register_vocab(
+                Message('register_vocab', {'entity_type': 'nav_skillGoKeyword'}))
+        warn.assert_called_once()
+        self.assertEqual(pipeline.registered_vocab, before)


### PR DESCRIPTION
## What

`DomainAdaptPipeline` / `HierarchicalAdaptPipeline` crashed with `AttributeError: 'NoneType' object has no attribute 'startswith'` in `_resolve_entity_domain` whenever a legacy regex `register_vocab` payload (which carries no `entity_type`) arrived after any intent had populated the entity-domain index — killing the bus executor mid-registration.

## Fix (OVOS-INTENT-4 §6.3 / §5.3)

- `register_vocabulary` (domain pipelines): regex payloads are routed by their named group — the group name is the entity_type, skill-id prefixed by the emitter (`munge_regex`) — so the regex lands in its owning skill's domain. A regex with no named group falls back to the shared default domain.
- `_resolve_entity_domain` guards a null routing key instead of crashing.
- `handle_register_vocab` (all pipelines): payloads carrying neither a regex nor a complete `entity_value`/`entity_type` pair are skipped with a WARN naming the topic, lang and offending fields; the registration is rejected only because nothing usable remains, and the executor never crashes.

## Tests

`test/test_register_vocab_partial_payload.py` reproduces the exact crash payload (regex-only registration after an intent registration) for both domain pipelines, verifies domain routing of the regex, an end-to-end match through the routed regex, and the skip-with-warning path. Full suite green (124 passed) in a fresh uv venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)